### PR TITLE
Refactor header navigation to use simulation API facade

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { GameSpeed, Alert, AlertLocation } from '../game/types';
+import type { GameSpeed, AlertSummaryDTO } from '@/src/game/api';
 
 interface DashboardProps {
   capital: number;
@@ -17,8 +17,8 @@ interface DashboardProps {
   gameSpeed: GameSpeed;
   onSetGameSpeed: (speed: GameSpeed) => void;
   currentView: 'structures' | 'finances' | 'personnel';
-  alerts: Alert[];
-  onNavigateToAlert: (alert: Alert) => void;
+  alerts: AlertSummaryDTO[];
+  onNavigateToAlert: (alert: AlertSummaryDTO) => void;
   onAcknowledgeAlert: (alertId: string) => void;
   onGameMenuToggle: (isOpen: boolean) => void;
 }

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import { Structure, Room, Zone } from '../game/types';
+import type {
+  StructureSummaryDTO,
+  RoomSummaryDTO,
+  ZoneSummaryDTO,
+} from '@/src/game/api';
 
 interface NavigationProps {
-  structure: Structure | null;
-  room: Room | null;
-  zone: Zone | null;
+  structure: StructureSummaryDTO | null;
+  room: RoomSummaryDTO | null;
+  zone: ZoneSummaryDTO | null;
   onBack: () => void;
   onRootClick: () => void;
   onStructureClick: () => void;

--- a/src/game/api/dto.ts
+++ b/src/game/api/dto.ts
@@ -10,6 +10,21 @@ export interface HealthEventDTO {
   criticalPlantIds: string[];
 }
 
+export interface AlertLocationDTO {
+  structureId: string;
+  roomId: string;
+  zoneId: string;
+}
+
+export interface AlertSummaryDTO {
+  id: string;
+  type: string;
+  message: string;
+  location?: AlertLocationDTO;
+  isAcknowledged?: boolean;
+  context?: unknown;
+}
+
 export interface WorldSummaryDTO {
   tick: number;
   company: {
@@ -26,16 +41,7 @@ export interface WorldSummaryDTO {
     plants: number;
     devices: number;
   };
-  alerts: Array<{
-    id: string;
-    type: string;
-    message: string;
-    location?: {
-      structureId: string;
-      roomId: string;
-      zoneId: string;
-    };
-  }>;
+  alerts: AlertSummaryDTO[];
 }
 
 export interface SimTickEventDTO {
@@ -68,11 +74,24 @@ export interface AlertEventDTO {
   alertId: string;
   type: string;
   message: string;
-  location: {
-    structureId: string;
-    roomId: string;
-    zoneId: string;
-  };
+  location: AlertLocationDTO;
+}
+
+export interface StructureSummaryDTO {
+  id: string;
+  name: string;
+}
+
+export interface RoomSummaryDTO {
+  id: string;
+  name: string;
+  structureId: string;
+}
+
+export interface ZoneSummaryDTO {
+  id: string;
+  name: string;
+  roomId: string;
 }
 
 export type SimulationEventMap = {

--- a/src/game/api/index.ts
+++ b/src/game/api/index.ts
@@ -23,8 +23,15 @@ export type {
   SimulationSnapshot,
   SimulationStartOptions,
   SimTickEventDTO,
+  AlertSummaryDTO,
+  AlertLocationDTO,
+  StructureSummaryDTO,
+  RoomSummaryDTO,
+  ZoneSummaryDTO,
   WorldSummaryDTO,
 };
+
+export type { GameSpeed };
 
 export async function start(options?: SimulationStartOptions): Promise<WorldSummaryDTO | null> {
   return adapter.start(options);

--- a/src/game/internal/engineAdapter.ts
+++ b/src/game/internal/engineAdapter.ts
@@ -239,6 +239,8 @@ function mapWorldSummary(state: GameState): WorldSummaryDTO {
             zoneId: alert.location.zoneId,
           }
         : undefined,
+      isAcknowledged: alert.isAcknowledged,
+      context: alert.context,
     })),
   };
 }


### PR DESCRIPTION
## Summary
- add DTOs for alerts and navigation summaries to the game API facade and expose GameSpeed
- map acknowledgement/context data in the engine adapter for world summaries
- migrate dashboard and navigation components (and App wiring) to consume the new facade types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc9fca415c8325a503e58e95bf599f