### PR TITLE
Add health data skeleton and API accessors

### DIFF
--- a/src/game/api/index.ts
+++ b/src/game/api/index.ts
@@ -1,14 +1,30 @@
 import type { GameSpeed } from '@/game/types';
+import {
+  listHealthDefinitions as loadHealthDefinitions,
+  listTreatmentOptions as loadTreatmentOptions,
+} from '@/game/health/loader';
+import type {
+  DiseaseBalancingConfig,
+  HealthDefinitionSummary,
+  PestBalancingConfig,
+  TreatmentCatalog,
+  TreatmentOption,
+} from '@/game/health/types';
 import { EventBus } from './eventBus';
 import type {
   ApplyTreatmentOptions,
   ApplyTreatmentResult,
+  AlertLocationDTO,
+  AlertSummaryDTO,
+  RoomSummaryDTO,
   SimulationEventMap,
   SimulationEventName,
   SimulationSnapshot,
   SimulationStartOptions,
   SimTickEventDTO,
+  StructureSummaryDTO,
   WorldSummaryDTO,
+  ZoneSummaryDTO,
 } from './dto';
 import { EngineAdapter } from '../internal/engineAdapter';
 
@@ -32,6 +48,13 @@ export type {
 };
 
 export type { GameSpeed };
+export type {
+  DiseaseBalancingConfig,
+  HealthDefinitionSummary,
+  PestBalancingConfig,
+  TreatmentCatalog,
+  TreatmentOption,
+};
 
 export async function start(options?: SimulationStartOptions): Promise<WorldSummaryDTO | null> {
   return adapter.start(options);
@@ -62,4 +85,12 @@ export function getSnapshot(): SimulationSnapshot {
 
 export function applyTreatment(options: ApplyTreatmentOptions): ApplyTreatmentResult {
   return adapter.applyTreatment(options);
+}
+
+export async function listTreatments(): Promise<TreatmentOption[]> {
+  return loadTreatmentOptions();
+}
+
+export async function listHealthDefs(): Promise<HealthDefinitionSummary> {
+  return loadHealthDefinitions();
 }

--- a/src/game/health/loader.ts
+++ b/src/game/health/loader.ts
@@ -1,0 +1,84 @@
+import type {
+  DiseaseBalancingConfig,
+  HealthDefinitionData,
+  HealthDefinitionSummary,
+  PestBalancingConfig,
+  TreatmentCatalog,
+  TreatmentOption,
+} from './types';
+
+const DISEASE_CONFIG_URL = '/data/configs/disease_balancing.json';
+const PEST_CONFIG_URL = '/data/configs/pest_balancing.json';
+const TREATMENT_CONFIG_URL = '/data/configs/treatment_options.json';
+
+let memory: HealthDefinitionData | null = null;
+let loadPromise: Promise<HealthDefinitionData> | null = null;
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load health config from ${url}: ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as T;
+}
+
+async function load(): Promise<HealthDefinitionData> {
+  const [diseaseBalancing, pestBalancing, treatmentCatalog] = await Promise.all([
+    fetchJson<DiseaseBalancingConfig>(DISEASE_CONFIG_URL),
+    fetchJson<PestBalancingConfig>(PEST_CONFIG_URL),
+    fetchJson<TreatmentCatalog>(TREATMENT_CONFIG_URL),
+  ]);
+
+  return {
+    diseaseBalancing,
+    pestBalancing,
+    treatmentCatalog,
+  };
+}
+
+export async function loadHealthData(): Promise<HealthDefinitionData> {
+  if (memory) {
+    return memory;
+  }
+
+  if (!loadPromise) {
+    loadPromise = load()
+      .then((result) => {
+        memory = result;
+        return result;
+      })
+      .catch((error) => {
+        loadPromise = null;
+        throw error;
+      });
+  }
+
+  return loadPromise;
+}
+
+export async function ensureHealthData(): Promise<HealthDefinitionData> {
+  if (memory) {
+    return memory;
+  }
+  return loadHealthData();
+}
+
+export function getHealthData(): HealthDefinitionData {
+  if (!memory) {
+    throw new Error('Health definitions are not loaded yet. Call loadHealthData() first.');
+  }
+  return memory;
+}
+
+export async function listTreatmentOptions(): Promise<TreatmentOption[]> {
+  const data = await ensureHealthData();
+  return data.treatmentCatalog.options;
+}
+
+export async function listHealthDefinitions(): Promise<HealthDefinitionSummary> {
+  const data = await ensureHealthData();
+  return {
+    diseases: data.diseaseBalancing,
+    pests: data.pestBalancing,
+  };
+}

--- a/src/game/health/types.ts
+++ b/src/game/health/types.ts
@@ -1,0 +1,248 @@
+export type PlantLifecycleStage =
+  | 'seedling'
+  | 'vegetation'
+  | 'earlyFlower'
+  | 'lateFlower'
+  | 'ripening'
+  | (string & {});
+
+export type TreatmentTarget = 'disease' | 'pest' | (string & {});
+
+export type TreatmentCategory =
+  | 'cultural'
+  | 'biological'
+  | 'mechanical'
+  | 'chemical'
+  | 'physical'
+  | (string & {});
+
+export type TreatmentCostBasis = 'perZone' | 'perPlant' | 'perSquareMeter' | (string & {});
+
+export interface DiseaseTreatmentEfficacy {
+  infectionMultiplier?: number;
+  degenerationMultiplier?: number;
+  recoveryMultiplier?: number;
+}
+
+export interface PestTreatmentEfficacy {
+  reproductionMultiplier?: number;
+  mortalityMultiplier?: number;
+  damageMultiplier?: number;
+}
+
+export interface TreatmentCosts {
+  laborMinutes?: number;
+  materialsCost?: number;
+  energyPerHourKWh?: number;
+  equipmentRentalEUR?: number;
+  [key: string]: number | undefined;
+}
+
+export interface TreatmentRisks {
+  [key: string]: string | boolean | number | undefined;
+}
+
+export interface TreatmentOption {
+  id: string;
+  name: string;
+  category: TreatmentCategory;
+  targets: TreatmentTarget[];
+  applicability: PlantLifecycleStage[];
+  efficacy: {
+    disease?: DiseaseTreatmentEfficacy;
+    pest?: PestTreatmentEfficacy;
+    [key: string]: DiseaseTreatmentEfficacy | PestTreatmentEfficacy | undefined;
+  };
+  costs: TreatmentCosts;
+  cooldownDays: number;
+  notes?: string;
+  costBasis: TreatmentCostBasis;
+  risks?: TreatmentRisks;
+}
+
+export interface TreatmentStackingRules {
+  maxConcurrentTreatmentsPerZone: number;
+  mechanicalAlwaysStacks: boolean;
+  chemicalAndBiologicalCantShareSameMoAWithin7Days: boolean;
+  cooldownDaysDefault: number;
+  [key: string]: number | boolean;
+}
+
+export interface TreatmentSideEffects {
+  phytotoxicityRiskKeys: string[];
+  beneficialsHarmRiskKeys: string[];
+  [key: string]: string[] | undefined;
+}
+
+export interface TreatmentCostBasisDescriptions {
+  perZone?: string;
+  perPlant?: string;
+  perSquareMeter?: string;
+  [key: string]: string | undefined;
+}
+
+export interface TreatmentCostModelInfo {
+  costBasis: TreatmentCostBasisDescriptions;
+  totalCostFormula: string;
+}
+
+export interface TreatmentGlobalConfig {
+  stackingRules: TreatmentStackingRules;
+  sideEffects: TreatmentSideEffects;
+  costModel: TreatmentCostModelInfo;
+}
+
+export interface TreatmentCatalog {
+  kind: string;
+  version: string;
+  notes?: string;
+  global: TreatmentGlobalConfig;
+  options: TreatmentOption[];
+}
+
+export interface RangeDescriptor {
+  min: number;
+  max: number;
+}
+
+export type NumericTuple = [number, number];
+
+export interface DiseaseBalancingGlobalConfig {
+  baseDailyInfectionMultiplier: number;
+  baseRecoveryMultiplier: number;
+  maxConcurrentDiseases: number;
+  symptomDelayDays: RangeDescriptor;
+  eventWeights: Record<string, number>;
+  [key: string]: number | RangeDescriptor | Record<string, number>;
+}
+
+export interface DiseasePhaseMultipliers {
+  infection?: number;
+  degeneration?: number;
+  recovery?: number;
+  [key: string]: number | undefined;
+}
+
+export type DiseasePhaseMultiplierMap = Record<string, DiseasePhaseMultipliers>;
+
+export type DiseaseEnvironmentModifier = Record<string, number | NumericTuple | undefined>;
+
+export type DiseaseEnvironmentModifiers = Record<string, DiseaseEnvironmentModifier | undefined>;
+
+export interface DiseaseStrainResistanceWeights {
+  generalResilienceWeight?: number;
+  specificResistanceWeight?: number;
+  [key: string]: number | undefined;
+}
+
+export type DiseaseTreatmentClassEfficacy = DiseaseTreatmentEfficacy;
+
+export type DiseaseTreatmentEfficacyMap = Record<string, DiseaseTreatmentClassEfficacy>;
+
+export interface DiseaseCaps {
+  minDailyDegeneration: number;
+  maxDailyDegeneration: number;
+  minDailyRecovery: number;
+  maxDailyRecovery: number;
+  [key: string]: number;
+}
+
+export interface DiseaseIntegrationHints {
+  applyOrder?: string[];
+  mapToDiseaseModel?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export interface DiseaseBalancingConfig {
+  kind: string;
+  version: string;
+  notes?: string;
+  global: DiseaseBalancingGlobalConfig;
+  phaseMultipliers: DiseasePhaseMultiplierMap;
+  environmentModifiers: DiseaseEnvironmentModifiers;
+  strainResistanceWeights: DiseaseStrainResistanceWeights;
+  treatmentEfficacy: DiseaseTreatmentEfficacyMap;
+  caps: DiseaseCaps;
+  integrationHints?: DiseaseIntegrationHints;
+}
+
+export interface PestEconomicThresholds {
+  photosynthesisReductionAlert: number;
+  rootUptakeReductionAlert: number;
+  budLossAlert: number;
+  [key: string]: number;
+}
+
+export interface PestBalancingGlobalConfig {
+  baseDailyReproductionMultiplier: number;
+  baseDailyMortalityMultiplier: number;
+  baseDamageMultiplier: number;
+  maxConcurrentPests: number;
+  economicThresholds: PestEconomicThresholds;
+  eventWeights: Record<string, number>;
+  [key: string]: number | PestEconomicThresholds | Record<string, number>;
+}
+
+export interface PestPhaseMultipliers {
+  reproduction?: number;
+  damage?: number;
+  mortality?: number;
+  [key: string]: number | undefined;
+}
+
+export type PestPhaseMultiplierMap = Record<string, PestPhaseMultipliers>;
+
+export type PestEnvironmentModifier = Record<string, number | NumericTuple | undefined>;
+
+export type PestEnvironmentModifiers = Record<string, PestEnvironmentModifier | undefined>;
+
+export interface PestNaturalEnemiesConfig {
+  backgroundPredationPerDay: number;
+  enhancedPredationWithBiocontrol: number;
+  [key: string]: number;
+}
+
+export type PestControlEfficacyMap = Record<string, PestTreatmentEfficacy>;
+
+export type PestDiseaseInteraction = Record<string, number>;
+
+export interface PestCaps {
+  minDailyReproduction: number;
+  maxDailyReproduction: number;
+  minDailyMortality: number;
+  maxDailyMortality: number;
+  minDailyDamage: number;
+  maxDailyDamage: number;
+  [key: string]: number;
+}
+
+export interface PestIntegrationHints {
+  applyOrder?: string[];
+  mapToPestModel?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export interface PestBalancingConfig {
+  kind: string;
+  version: string;
+  notes?: string;
+  global: PestBalancingGlobalConfig;
+  phaseMultipliers: PestPhaseMultiplierMap;
+  environmentModifiers: PestEnvironmentModifiers;
+  naturalEnemies: PestNaturalEnemiesConfig;
+  controlEfficacy: PestControlEfficacyMap;
+  diseaseInteraction: PestDiseaseInteraction;
+  caps: PestCaps;
+  integrationHints?: PestIntegrationHints;
+}
+
+export interface HealthDefinitionSummary {
+  diseases: DiseaseBalancingConfig;
+  pests: PestBalancingConfig;
+}
+
+export interface HealthDefinitionData {
+  diseaseBalancing: DiseaseBalancingConfig;
+  pestBalancing: PestBalancingConfig;
+  treatmentCatalog: TreatmentCatalog;
+}


### PR DESCRIPTION
## Summary
- add typed health data definitions covering disease, pest, and treatment catalogs
- load health configuration JSON into memory with a reusable health loader
- expose API helpers to list treatments and health definitions without altering simulation behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccab432e4c8325b15cfe09438f7fb5