### PR TITLE
Add facade documentation and CI guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run lint checks
+        run: npm run lint
+
+      - name: Build application
+        run: npm run build
+        env:
+          CI: true

--- a/docs/architecture/facade.md
+++ b/docs/architecture/facade.md
@@ -1,0 +1,80 @@
+# Gameplay-Fassade (`@/game/api`)
+
+Die Fassade unter `@/game/api` bündelt alle öffentlichen Einstiegsfunktionen für Simulation, Telemetrie und Gesundheitsdaten. Sie kapselt den `EngineAdapter` sowie interne Loader, damit UI- und Tooling-Teams ohne tiefe Modulkenntnis arbeiten können. Dieses Dokument beschreibt die Exportoberfläche, das Eventmodell und die wichtigsten DTOs.
+
+## Ziele & Prinzipien
+
+- **Stabile Verträge:** Konsumenten greifen ausschließlich über `@/game/api` auf die Simulation zu. Interne Pfade (z. B. `src/game/internal`) bleiben austauschbar.
+- **Deterministische Steuerung:** Start-, Pause- und Step-Aufrufe führen deterministische Tick-Übergänge aus. Alle Events enthalten `tick` und `timestamp`.
+- **Sichere Erweiterbarkeit:** Neue Events oder DTO-Felder sind additive Änderungen. Bestehende Felder werden nicht entfernt.
+
+## Schnellstart
+
+```ts
+import {
+  start,
+  pause,
+  step,
+  setSpeed,
+  on,
+  getSnapshot,
+  applyTreatment,
+  listTreatments,
+  listHealthDefs,
+} from '@/game/api';
+```
+
+1. **Simulation bootstrappen:** `await start({ companyName, seed, reset })` initialisiert Zustand, primt den Jobmarkt und liefert eine `WorldSummaryDTO` zurück.
+2. **Events abonnieren:** `const off = on('sim:tick', handleTick)` registriert Listener; der Rückgabewert entfernt den Listener wieder.
+3. **Loop steuern:** `setSpeed(speed)` passt die Tickfrequenz an, `pause()` stoppt das Intervall, `await step()` erzwingt genau einen Tick.
+4. **Snapshot ziehen:** `getSnapshot()` liefert den letzten `WorldSummaryDTO`-Stand ohne neuen Tick.
+5. **Behandlungen auslösen:** `applyTreatment()` liefert aktuell nur ein standardisiertes Fehlerobjekt, bleibt aber die Schnittstelle für spätere Maßnahmen.
+6. **Stammdaten laden:** `listTreatments()` und `listHealthDefs()` liefern katalogisierte Optionen bzw. Definitionen aus dem Health-Modul.
+
+## Events & EventBus
+
+Die Fassade verwendet einen synchronen `EventBus`. Listener werden sofort zur Tickzeit aufgerufen – blockierende oder fehlerhafte Listener verzögern den Loop. Guardrails:
+
+- Fehler im Listener werden abgefangen und geloggt, beenden aber nicht den Bus.
+- Verwenden Sie den Rückgabewert von `on(...)`, um Listener bei Komponenten-Unmounts zuverlässig zu deregistrieren.
+- Die Eventnamen sind typsicher (`SimulationEventName`), wodurch TypeScript den Payload-Typ aus `SimulationEventMap` ableitet.
+
+### Eventübersicht
+
+| Eventname        | Auslöser                                                  | Payload DTO              | Hinweise |
+| ---------------- | --------------------------------------------------------- | ------------------------ | -------- |
+| `sim:tick`       | Nach erfolgreichem `gameTick`                             | `SimTickEventDTO`        | Enthält Kapitalveränderungen, aktiven Speed und Health-Aggregate. |
+| `finance:update` | Für jede neue Buchungsdifferenz seit letztem Tick        | `FinanceUpdateEventDTO`  | Liefert Delta pro Einnahmen-/Ausgabenkategorie. |
+| `health:event`   | Bei jedem Tick nach Health-Aggregation                    | `HealthEventDTO`         | Aggregierte Gesundheits- und Stresswerte samt kritischen Pflanzen. |
+| `world:summary`  | Bei jeder Initialisierung sowie nach jedem Tick           | `WorldSummaryDTO`        | Globale Totals und aktive Alerts, geeignet für Dashboard-Header. |
+| `alert:event`    | Für neu erkannte Alerts im Vergleich zum vorherigen Tick | `AlertEventDTO`          | Liefert Standortinformationen für UI-Highlighting. |
+
+## DTO-Leitfaden
+
+Die DTOs sind in `src/game/api/dto.ts` definiert. Wichtige Felder:
+
+- **`WorldSummaryDTO`** – Unternehmens-ID/-Name, Kapital, kumulierte Erträge sowie Totals für Strukturen, Räume, Zonen, Plantings, Pflanzen und Geräte.
+- **`SimTickEventDTO`** – Tick, `timestamp`, aktueller `GameSpeed`, RNG-Seed, Kapitalstand und Delta, kumulierte Erträge sowie `plantHealth`-Auszug und Anzahl aktiver Alerts.
+- **`HealthEventDTO`** – Pflanzanzahl, Durchschnittswerte für Health/Stress, Minimum sowie Liste kritischer Pflanz-IDs.
+- **`FinanceUpdateEventDTO`** – Delta pro Kategorie, positives Delta für Erlöse, negatives Delta für Kosten (`reason` präfixiert mit `revenue:` oder `expense:`).
+- **`AlertEventDTO`** – Neue Alerts inklusive strukturierter Lokation (`AlertLocationDTO`).
+- **`SimulationStartOptions`** – Optionales `companyName`, deterministischer `seed` sowie `reset`-Flag für harte Neustarts.
+- **`ApplyTreatmentResult`** – Platzhalterstruktur für die zukünftige Maßnahmenverarbeitung.
+
+Alle DTOs verwenden SI-konforme Einheiten wie im Projektstandard festgelegt (z. B. Gramm für Biomasse, Euro für Kapital implizit). Felder werden niemals in-place mutiert; erstellen Sie bei Ableitungen Kopien.
+
+## Steuerung & Tick-Regeln
+
+- `start()` und `step()` initialisieren bei gesetztem `reset` immer einen frischen Zustand (inklusive deterministischer RNG-Seed-Initialisierung via `mulberry32`).
+- `setSpeed()` setzt eine Obergrenze von 10 Hz (`MIN_TICK_INTERVAL_MS`). Höhere Werte werden automatisch auf diese Grenze gekappt.
+- `pause()` stoppt lediglich das Intervall; bereits laufende Ticks werden zu Ende geführt.
+- Der EngineAdapter sendet beim Initialisieren direkt einen `world:summary` und `health:event`, bevor weitere Ticks laufen.
+
+## Best Practices
+
+- **Keine Deep Imports:** UI-Schichten importieren ausschließlich aus `@/game/api`, nicht aus `@/game/internal` oder ähnlichen Pfaden.
+- **Listener räumen:** Verwenden Sie die Rückgabefunktion von `on(...)` oder kapseln Sie Abos in React `useEffect`, um Leaks zu vermeiden.
+- **Keine Blockaden:** Event-Handler sollten maximal Daten sammeln und Rendering triggern. Schwergewichtige Berechnungen in Worker auslagern.
+- **Testbarkeit:** Mocken Sie den EventBus bei Unit-Tests, indem Sie `on` und `emit` über die Fassade stubben. DTOs können direkt aus `@/game/api` importiert werden.
+
+Durch diese Leitplanken bleibt die Gameplay-Fassade austauschbar, während Frontend- und Tooling-Teams eine klar dokumentierte API erhalten.

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -1,0 +1,55 @@
+# Deprecation-Policy
+
+Diese Richtlinie beschreibt, wie wir Altmodule kennzeichnen, ohne sie zu entfernen. Ziel ist es, Konsumenten rechtzeitig über Ablösungen zu informieren und Migrationspfade transparent zu halten, während die bestehende Funktionalität funktionsfähig bleibt.
+
+## Grundprinzipien
+
+1. **Keine stillen Brüche:** Deprecated-APIs liefern weiterhin dieselben Ergebnisse, solange sie bestehen.
+2. **Dokumentation statt Löschung:** Jede Abkündigung wird hier dokumentiert und im Code markiert.
+3. **Alternativen anbieten:** Nennt immer eine empfohlene Nachfolge-API oder Workaround.
+4. **Verbindliche Kommunikation:** Konsumenten sehen Deprecation-Hinweise sowohl im Code (TypeScript IntelliSense) als auch in der Laufzeit (Dev-Warnung).
+
+## Kennzeichnungsschritte
+
+1. **Dokumentation ergänzen:** Fügen Sie im Abschnitt [Registrierte Deprecations](#registrierte-deprecations) einen Eintrag mit Modul, Datum, Begründung und empfohlenem Ersatz hinzu.
+2. **Code markieren:** Verwenden Sie einen JSDoc-Kommentar direkt am Export. Beispiel:
+
+   ```ts
+   /**
+    * @deprecated Verwende stattdessen `@/game/api` → `start`.
+    */
+   export function legacyStart(...) { /* ... */ }
+   ```
+
+3. **Dev-Warnung ausgeben:** Hinterlegen Sie im betroffenen Modul einen `console.warn` mit Hinweis und Zielversion, jedoch nur in Nicht-Produktivumgebungen:
+
+   ```ts
+   if (process.env.NODE_ENV !== 'production') {
+     console.warn('[deprecation] legacyStart ist veraltet und wird ab v1.2 entfernt.');
+   }
+   ```
+
+4. **Verwendung einschränken:** Ergänzen Sie bei Bedarf ESLint-Regeln (`no-restricted-imports`), um Neubefüllung zu verhindern.
+5. **Migrationspfad beschreiben:** Falls zusätzliche Schritte nötig sind (z. B. DTO-Konvertierungen), dokumentieren Sie diese im jeweiligen Modul-README.
+
+## Lifecycle
+
+- **Ankündigung:** Deprecation-Eintrag in diesem Dokument + Release Notes.
+- **Übergangsphase:** Mindestens zwei Minor-Versionen Laufzeit mit Warnungen und Tests.
+- **Entfernung:** Erst wenn alle abhängigen Module migriert sind und eine Freigabe erfolgt ist. Die Entfernung erhält einen eigenen Changelog-Eintrag.
+
+## Registrierte Deprecations
+
+| Modul / Export        | Seit Version | Ersatz / Aktion                | Status          |
+| --------------------- | ------------ | ------------------------------ | --------------- |
+| *(frei für zukünftige Einträge)* | –            | –                            | Aktiv (legacy) |
+
+## Review-Checkliste
+
+- [ ] JSDoc `@deprecated` gesetzt
+- [ ] Warnung in Dev-Builds vorhanden
+- [ ] Alternative dokumentiert
+- [ ] Tests angepasst (keine direkten Abhängigkeiten mehr in neuem Code)
+- [ ] Eintrag in `docs/deprecation.md`
+
+Mit diesem Prozess bleiben Altmodule nachvollziehbar, ohne laufende Features zu gefährden.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "lint": "node scripts/lint.mjs",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,75 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const projectRoot = process.cwd();
+const includeRoots = [
+  'App.tsx',
+  'index.tsx',
+  'components',
+  'hooks',
+  'views',
+  'src',
+  'game',
+];
+
+const allowedExtensions = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+const bannedPatterns = [
+  {
+    pattern: '@/game/internal',
+    message: 'verwende die öffentliche Fassade `@/game/api` statt interner Pfade',
+  },
+];
+
+const failures = [];
+
+async function walk(relativePath) {
+  const absolutePath = path.join(projectRoot, relativePath);
+  let fileStats;
+  try {
+    fileStats = await stat(absolutePath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  if (fileStats.isDirectory()) {
+    const entries = await readdir(absolutePath);
+    await Promise.all(entries.map(entry => walk(path.join(relativePath, entry))));
+    return;
+  }
+
+  const extension = path.extname(relativePath);
+  if (!allowedExtensions.has(extension)) {
+    return;
+  }
+
+  const content = await readFile(absolutePath, 'utf8');
+  bannedPatterns.forEach(({ pattern, message }) => {
+    if (content.includes(pattern)) {
+      failures.push({ file: relativePath, pattern, message });
+    }
+  });
+}
+
+async function main() {
+  await Promise.all(includeRoots.map(root => walk(root)));
+
+  if (failures.length > 0) {
+    console.error('Lint-Checks fehlgeschlagen:');
+    failures.forEach(({ file, pattern, message }) => {
+      console.error(` - ${file} enthält "${pattern}": ${message}`);
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('Lint-Checks erfolgreich.');
+}
+
+main().catch(error => {
+  console.error('Lint-Skript abgebrochen:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- document the public gameplay facade (`@/game/api`) including lifecycle, events and DTO guardrails
- capture the project-wide deprecation policy so legacy modules can be marked without deleting them
- wire lint + build into CI with a lightweight lint script that blocks deep imports from `@/game/internal`

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccaf1208ac83258e210f93fcc36af4