### PR TITLE
Fix RoomPurpose type re-export

### DIFF
--- a/game/types.ts
+++ b/game/types.ts
@@ -1,6 +1,6 @@
 
 
-import { RoomPurpose } from './roomPurposes';
+import type { RoomPurpose } from './roomPurposes';
 import { Company } from './models/Company';
 import { Structure } from './models/Structure';
 import { Room } from './models/Room';
@@ -8,7 +8,8 @@ import { Zone } from './models/Zone';
 import { Planting } from './models/Planting';
 import { Plant } from './models/Plant';
 
-export { Company, Structure, Room, Zone, Planting, Plant, RoomPurpose };
+export { Company, Structure, Room, Zone, Planting, Plant };
+export type { RoomPurpose };
 
 export interface StructureBlueprint {
   id: string;


### PR DESCRIPTION
## Summary
- update the types aggregator to import the `RoomPurpose` symbol as a type-only dependency
- re-export `RoomPurpose` as a type so the runtime bundle stops requesting a missing value export

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ccba7f11d08325a56bcc1aebf2423b