### PR TITLE
refactor: route UI through game API facade

### DIFF
--- a/components/BreedingStation.tsx
+++ b/components/BreedingStation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Company } from '../game/types';
+import { Company } from '@/src/game/api';
 
 interface BreedingStationProps {
   company: Company;

--- a/components/RoomDetail.tsx
+++ b/components/RoomDetail.tsx
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
-import { Company, Room, Structure, Zone } from '../game/types';
-import { roomPurposes } from '../game/roomPurposes';
-import { getBlueprints, getAvailableStrains } from '../game/blueprints';
+import {
+  Company,
+  Room,
+  Structure,
+  Zone,
+  roomPurposes,
+  getBlueprints,
+  getAvailableStrains,
+} from '@/src/game/api';
 import BreedingStation from './BreedingStation';
 
 interface RoomDetailProps {

--- a/components/StructureDetail.tsx
+++ b/components/StructureDetail.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
-import { Company, Room, Structure } from '../game/types';
-import { roomPurposes } from '../game/roomPurposes';
-import { getAvailableStrains } from '../game/blueprints';
+import {
+  Company,
+  Room,
+  Structure,
+  roomPurposes,
+  getAvailableStrains,
+} from '@/src/game/api';
 
 interface StructureDetailProps {
   structure: Structure;

--- a/components/Structures.tsx
+++ b/components/Structures.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Company } from '../game/types';
-import { getAvailableStrains } from '../game/blueprints';
+import { Company, getAvailableStrains } from '@/src/game/api';
 
 interface StructuresProps {
   company: Company;

--- a/components/ZoneDeviceList.tsx
+++ b/components/ZoneDeviceList.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { Zone, GroupedDeviceInfo } from '../game/types';
-import { getBlueprints } from '../game/blueprints';
+import { Zone, GroupedDeviceInfo, getBlueprints } from '@/src/game/api';
 
 // Props for the new component
 interface ZoneDeviceListProps {

--- a/components/ZoneInfoPanel.tsx
+++ b/components/ZoneInfoPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Zone, Structure } from '../game/types';
-import { getBlueprints } from '../game/blueprints';
+import { Zone, Structure, getBlueprints } from '@/src/game/api';
 
 interface ZoneInfoPanelProps {
   zone: Zone;

--- a/components/ZonePlantingList.tsx
+++ b/components/ZonePlantingList.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { Zone, Company } from '../game/types';
-import { getAvailableStrains } from '../game/blueprints';
-import { GrowthStage } from '../game/models/Plant';
+import { Zone, Company, getAvailableStrains, GrowthStage } from '@/src/game/api';
 
 interface ZonePlantingListProps {
   zone: Zone;

--- a/components/ZonePlantingPlan.tsx
+++ b/components/ZonePlantingPlan.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Zone, Company } from '../game/types';
-import { getAvailableStrains } from '../game/blueprints';
+import { Zone, Company, getAvailableStrains } from '@/src/game/api';
 
 interface ZonePlantingPlanProps {
     zone: Zone;

--- a/components/modals/content/AddDeviceModalContent.tsx
+++ b/components/modals/content/AddDeviceModalContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getBlueprints } from '../../../game/blueprints';
+import { getBlueprints } from '@/src/game/api';
 
 const AddDeviceModalContent = ({ gameState, formState, updateForm, handlers, closeModal, selectedRoom, selectedStructure, modalState }) => {
     const deviceBlueprints = getBlueprints().devices;

--- a/components/modals/content/AddRoomModalContent.tsx
+++ b/components/modals/content/AddRoomModalContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { roomPurposes, RoomPurpose } from '../../../game/roomPurposes';
+import { roomPurposes, RoomPurpose } from '@/src/game/api';
 
 const AddRoomModalContent = ({ formState, updateForm, handlers, closeModal, selectedStructure }) => {
     return (

--- a/components/modals/content/AddSupplyModalContent.tsx
+++ b/components/modals/content/AddSupplyModalContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getBlueprints } from '../../../game/blueprints';
+import { getBlueprints } from '@/src/game/api';
 
 const AddSupplyModalContent = ({ gameState, formState, updateForm, handlers, closeModal }) => {
     const { utilityPrices } = getBlueprints();

--- a/components/modals/content/AddZoneModalContent.tsx
+++ b/components/modals/content/AddZoneModalContent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { getBlueprints } from '../../../game/blueprints';
-import { CultivationMethodBlueprint } from '../../../game/types';
+import { getBlueprints, CultivationMethodBlueprint } from '@/src/game/api';
 
 const AddZoneModalContent = ({ formState, updateForm, handlers, closeModal, selectedRoom }) => {
     return (

--- a/components/modals/content/BreedStrainModalContent.tsx
+++ b/components/modals/content/BreedStrainModalContent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { getAvailableStrains } from '../../../game/blueprints';
-import { StrainBlueprint } from '../../../game/types';
+import { getAvailableStrains, StrainBlueprint } from '@/src/game/api';
 
 const TraitDisplay = ({ strain }: { strain: StrainBlueprint | null }) => {
     if (!strain) return <div className="trait-display"></div>;

--- a/components/modals/content/EditDeviceModalContent.tsx
+++ b/components/modals/content/EditDeviceModalContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getBlueprints } from '../../../game/blueprints';
+import { getBlueprints } from '@/src/game/api';
 
 const EditDeviceModalContent = ({ modalState, formState, updateForm, handlers, closeModal, selectedRoom }) => {
     if (!modalState.itemToEdit || !selectedRoom) return null;

--- a/components/modals/content/HireEmployeeModalContent.tsx
+++ b/components/modals/content/HireEmployeeModalContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Employee, GameState } from '../../../game/types';
+import { Employee, GameState } from '@/src/game/api';
 
 const HireEmployeeModalContent = ({ gameState, modalState, formState, updateForm, handlers, closeModal }: { gameState: GameState, modalState: any, formState: any, updateForm: any, handlers: any, closeModal: any }) => {
     const employeeToHire: Employee | null = modalState.itemToHire;

--- a/components/modals/content/PlantStrainModalContent.tsx
+++ b/components/modals/content/PlantStrainModalContent.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getBlueprints, getAvailableStrains } from '../../../game/blueprints';
+import { getBlueprints, getAvailableStrains } from '@/src/game/api';
 
 const getNestedProperty = (obj: any, path: string) => {
   return path.split('.').reduce((o, p) => (o ? o[p] : undefined), obj);

--- a/components/modals/content/PlantingPlanModalContent.tsx
+++ b/components/modals/content/PlantingPlanModalContent.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getAvailableStrains, getBlueprints } from '../../../game/blueprints';
-import { StrainBlueprint } from '../../../game/types';
+import { getAvailableStrains, getBlueprints, StrainBlueprint } from '@/src/game/api';
 
 const getNestedProperty = (obj: any, path: string) => {
   return path.split('.').reduce((o, p) => (o ? o[p] : undefined), obj);

--- a/components/modals/content/RentModalContent.tsx
+++ b/components/modals/content/RentModalContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getBlueprints } from '../../../game/blueprints';
+import { getBlueprints } from '@/src/game/api';
 
 const RentModalContent = ({ gameState, formState, updateForm, handlers, closeModal }) => {
     const structureBlueprints = getBlueprints().structures;

--- a/components/modals/index.tsx
+++ b/components/modals/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Modal from '../Modal';
-import { GameState, Room, Structure } from '../../game/types';
+import { GameState, Room, Structure } from '@/src/game/api';
 
 // Import all the new content components
 import RentModalContent from './content/RentModalContent';

--- a/docs/architecture/facade.md
+++ b/docs/architecture/facade.md
@@ -18,9 +18,8 @@ import {
   setSpeed,
   on,
   getSnapshot,
-  applyTreatment,
-  listTreatments,
-  listHealthDefs,
+  applyTreatmentToZone,
+  applyTreatmentToPlant,
 } from '@/game/api';
 ```
 
@@ -28,8 +27,7 @@ import {
 2. **Events abonnieren:** `const off = on('sim:tick', handleTick)` registriert Listener; der Rückgabewert entfernt den Listener wieder.
 3. **Loop steuern:** `setSpeed(speed)` passt die Tickfrequenz an, `pause()` stoppt das Intervall, `await step()` erzwingt genau einen Tick.
 4. **Snapshot ziehen:** `getSnapshot()` liefert den letzten `WorldSummaryDTO`-Stand ohne neuen Tick.
-5. **Behandlungen auslösen:** `applyTreatment()` liefert aktuell nur ein standardisiertes Fehlerobjekt, bleibt aber die Schnittstelle für spätere Maßnahmen.
-6. **Stammdaten laden:** `listTreatments()` und `listHealthDefs()` liefern katalogisierte Optionen bzw. Definitionen aus dem Health-Modul.
+5. **Behandlungen auslösen:** `applyTreatmentToZone()` bzw. `applyTreatmentToPlant()` liefern aktuell standardisierte Fehlerobjekte, bilden aber den Einstieg für spätere Maßnahmen.
 
 ## Events & EventBus
 
@@ -46,7 +44,6 @@ Die Fassade verwendet einen synchronen `EventBus`. Listener werden sofort zur Ti
 | `sim:tick`       | Nach erfolgreichem `gameTick`                             | `SimTickEventDTO`        | Enthält Kapitalveränderungen, aktiven Speed und Health-Aggregate. |
 | `finance:update` | Für jede neue Buchungsdifferenz seit letztem Tick        | `FinanceUpdateEventDTO`  | Liefert Delta pro Einnahmen-/Ausgabenkategorie. |
 | `health:event`   | Bei jedem Tick nach Health-Aggregation                    | `HealthEventDTO`         | Aggregierte Gesundheits- und Stresswerte samt kritischen Pflanzen. |
-| `world:summary`  | Bei jeder Initialisierung sowie nach jedem Tick           | `WorldSummaryDTO`        | Globale Totals und aktive Alerts, geeignet für Dashboard-Header. |
 | `alert:event`    | Für neu erkannte Alerts im Vergleich zum vorherigen Tick | `AlertEventDTO`          | Liefert Standortinformationen für UI-Highlighting. |
 
 ## DTO-Leitfaden
@@ -68,7 +65,7 @@ Alle DTOs verwenden SI-konforme Einheiten wie im Projektstandard festgelegt (z.�
 - `start()` und `step()` initialisieren bei gesetztem `reset` immer einen frischen Zustand (inklusive deterministischer RNG-Seed-Initialisierung via `mulberry32`).
 - `setSpeed()` setzt eine Obergrenze von 10 Hz (`MIN_TICK_INTERVAL_MS`). Höhere Werte werden automatisch auf diese Grenze gekappt.
 - `pause()` stoppt lediglich das Intervall; bereits laufende Ticks werden zu Ende geführt.
-- Der EngineAdapter sendet beim Initialisieren direkt einen `world:summary` und `health:event`, bevor weitere Ticks laufen.
+- Der EngineAdapter aktualisiert beim Initialisieren sofort den Snapshot und sendet einen `health:event`, bevor weitere Ticks laufen.
 
 ## Best Practices
 

--- a/hooks/useGameState.ts
+++ b/hooks/useGameState.ts
@@ -1,9 +1,24 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { GameState, GameSpeed, StructureBlueprint, RoomPurpose, JobRole, Planting, Plant, Alert, Employee, PlantingPlan, OvertimePolicy } from '../game/types';
-import { initialGameState, gameTick } from '../game/engine';
-import { getBlueprints, getAvailableStrains, loadAllBlueprints } from '../game/blueprints';
-import { Company } from '../game/models/Company';
-import { mulberry32 } from '../game/utils';
+import {
+  GameState,
+  GameSpeed,
+  StructureBlueprint,
+  RoomPurpose,
+  JobRole,
+  Planting,
+  Plant,
+  Alert,
+  Employee,
+  PlantingPlan,
+  OvertimePolicy,
+  initialGameState,
+  gameTick,
+  getBlueprints,
+  getAvailableStrains,
+  loadAllBlueprints,
+  Company,
+  mulberry32,
+} from '@/src/game/api';
 
 const SAVE_LIST_KEY = 'weedbreed-save-list';
 const LAST_PLAYED_KEY = 'weedbreed-last-played';

--- a/hooks/useModals.ts
+++ b/hooks/useModals.ts
@@ -1,7 +1,14 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { RoomPurpose } from '../game/roomPurposes';
-import { getBlueprints, getAvailableStrains } from '../game/blueprints';
-import { Structure, Room, Company, GameState, Employee } from '../game/types';
+import {
+  RoomPurpose,
+  getBlueprints,
+  getAvailableStrains,
+  Structure,
+  Room,
+  Company,
+  GameState,
+  Employee,
+} from '@/src/game/api';
 
 type ModalType = 'rent' | 'addRoom' | 'addZone' | 'addDevice' | 'addSupply' | 'reset' | 'rename' | 'delete' | 'breedStrain' | 'plantStrain' | 'newGame' | 'save' | 'load' | 'editDevice' | 'editLightCycle' | 'hireEmployee' | 'negotiateSalary' | 'plantingPlan';
 

--- a/src/game/api/dto.ts
+++ b/src/game/api/dto.ts
@@ -98,7 +98,6 @@ export type SimulationEventMap = {
   'sim:tick': SimTickEventDTO;
   'finance:update': FinanceUpdateEventDTO;
   'health:event': HealthEventDTO;
-  'world:summary': WorldSummaryDTO;
   'alert:event': AlertEventDTO;
 };
 
@@ -114,17 +113,17 @@ export interface SimulationStepOptions extends SimulationStartOptions {}
 
 export type SimulationSnapshot = WorldSummaryDTO | null;
 
-export interface ApplyTreatmentOptions {
-  zoneId?: string;
-  plantId?: string;
-  treatment:
-    | 'water'
-    | 'nutrients'
-    | 'pesticide'
-    | 'prune'
-    | 'debug';
-  amount?: number;
-}
+export type ZoneTreatmentId =
+  | 'water'
+  | 'nutrients'
+  | 'pesticide'
+  | 'prune'
+  | 'debug';
+
+export type PlantTreatmentId =
+  | 'pesticide'
+  | 'prune'
+  | 'debug';
 
 export interface ApplyTreatmentResult {
   success: boolean;

--- a/src/game/api/index.ts
+++ b/src/game/api/index.ts
@@ -1,21 +1,10 @@
 import type { GameSpeed } from '@/game/types';
-import {
-  listHealthDefinitions as loadHealthDefinitions,
-  listTreatmentOptions as loadTreatmentOptions,
-} from '@/game/health/loader';
-import type {
-  DiseaseBalancingConfig,
-  HealthDefinitionSummary,
-  PestBalancingConfig,
-  TreatmentCatalog,
-  TreatmentOption,
-} from '@/game/health/types';
 import { EventBus } from './eventBus';
 import type {
-  ApplyTreatmentOptions,
   ApplyTreatmentResult,
   AlertLocationDTO,
   AlertSummaryDTO,
+  PlantTreatmentId,
   RoomSummaryDTO,
   SimulationEventMap,
   SimulationEventName,
@@ -25,6 +14,7 @@ import type {
   StructureSummaryDTO,
   WorldSummaryDTO,
   ZoneSummaryDTO,
+  ZoneTreatmentId,
 } from './dto';
 import { EngineAdapter } from '../internal/engineAdapter';
 
@@ -32,7 +22,6 @@ const bus = new EventBus<SimulationEventMap>();
 const adapter = new EngineAdapter(bus);
 
 export type {
-  ApplyTreatmentOptions,
   ApplyTreatmentResult,
   SimulationEventMap,
   SimulationEventName,
@@ -45,27 +34,28 @@ export type {
   RoomSummaryDTO,
   ZoneSummaryDTO,
   WorldSummaryDTO,
+  ZoneTreatmentId,
+  PlantTreatmentId,
 };
 
 export type { GameSpeed };
-export type {
-  DiseaseBalancingConfig,
-  HealthDefinitionSummary,
-  PestBalancingConfig,
-  TreatmentCatalog,
-  TreatmentOption,
-};
 
-export async function start(options?: SimulationStartOptions): Promise<WorldSummaryDTO | null> {
-  return adapter.start(options);
+export async function start(
+  seedOrOptions?: number | SimulationStartOptions,
+): Promise<WorldSummaryDTO | null> {
+  if (typeof seedOrOptions === 'number') {
+    return adapter.start({ seed: seedOrOptions });
+  }
+
+  return adapter.start(seedOrOptions);
 }
 
 export function pause(): void {
   adapter.pause();
 }
 
-export async function step(options?: SimulationStartOptions): Promise<SimTickEventDTO | null> {
-  return adapter.step(options);
+export async function step(steps?: number): Promise<SimTickEventDTO | null> {
+  return adapter.step(steps);
 }
 
 export function setSpeed(speed: GameSpeed): void {
@@ -83,14 +73,48 @@ export function getSnapshot(): SimulationSnapshot {
   return adapter.getSnapshot();
 }
 
-export function applyTreatment(options: ApplyTreatmentOptions): ApplyTreatmentResult {
-  return adapter.applyTreatment(options);
+export function applyTreatmentToZone(
+  zoneId: string,
+  treatmentId: ZoneTreatmentId,
+): ApplyTreatmentResult {
+  return adapter.applyTreatmentToZone(zoneId, treatmentId);
 }
 
-export async function listTreatments(): Promise<TreatmentOption[]> {
-  return loadTreatmentOptions();
+export function applyTreatmentToPlant(
+  plantId: string,
+  treatmentId: PlantTreatmentId,
+): ApplyTreatmentResult {
+  return adapter.applyTreatmentToPlant(plantId, treatmentId);
 }
 
-export async function listHealthDefs(): Promise<HealthDefinitionSummary> {
-  return loadHealthDefinitions();
-}
+export { Company, Structure, Room, Zone, Planting, Plant } from '@/game/types';
+
+export type {
+  GameState,
+  StructureBlueprint,
+  RoomPurpose,
+  JobRole,
+  Planting,
+  Plant,
+  PlantingPlan,
+  Alert,
+  Employee,
+  ExpenseCategory,
+  RevenueCategory,
+  GroupedDeviceInfo,
+  StrainBlueprint,
+  CultivationMethodBlueprint,
+  SkillName,
+  Trait,
+  OvertimePolicy,
+} from '@/game/types';
+
+export { roomPurposes } from '@/game/roomPurposes';
+export {
+  getBlueprints,
+  getAvailableStrains,
+  loadAllBlueprints,
+} from '@/game/blueprints';
+export { initialGameState, gameTick } from '@/game/engine';
+export { mulberry32 } from '@/game/utils';
+export { GrowthStage } from '@/game/models/Plant';

--- a/views/FinancesView.tsx
+++ b/views/FinancesView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Company, ExpenseCategory, RevenueCategory } from '../game/types';
+import { Company, ExpenseCategory, RevenueCategory } from '@/src/game/api';
 
 interface FinancesViewProps {
   company: Company;

--- a/views/MainView.tsx
+++ b/views/MainView.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Company, Structure, Room, Zone, JobRole, OvertimePolicy } from '../game/types';
+import {
+  Company,
+  Structure,
+  Room,
+  Zone,
+  JobRole,
+  OvertimePolicy,
+} from '@/src/game/api';
 import Structures from '../components/Structures';
 import StructureDetail from '../components/StructureDetail';
 import RoomDetail from '../components/RoomDetail';

--- a/views/PersonnelView.tsx
+++ b/views/PersonnelView.tsx
@@ -1,6 +1,13 @@
 
 import React, { useState } from 'react';
-import { Company, Employee, SkillName, Trait, JobRole, OvertimePolicy } from '../game/types';
+import {
+  Company,
+  Employee,
+  SkillName,
+  Trait,
+  JobRole,
+  OvertimePolicy,
+} from '@/src/game/api';
 
 const ALL_ROLES: JobRole[] = ['Gardener', 'Technician', 'Janitor', 'Botanist', 'Salesperson', 'Generalist'];
 

--- a/views/ZoneDetail.tsx
+++ b/views/ZoneDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Company, Zone, Structure, Room } from '../game/types';
+import { Company, Zone, Structure, Room } from '@/src/game/api';
 import ZoneInfoPanel from '../components/ZoneInfoPanel';
 import ZoneDeviceList from '../components/ZoneDeviceList';
 import ZonePlantingList from '../components/ZonePlantingList';


### PR DESCRIPTION
## Summary
- align `src/game/api` with the new façade contract and expose zone/plant treatments plus snapshot controls
- adjust the engine adapter to back the façade, maintaining the latest snapshot and updated step semantics
- rework UI imports to consume domain types and helpers exclusively via the façade and refresh the façade documentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccbf66ce108325ab27273e187900f5