### PR TITLE
Add zod-backed blueprint and health data loaders

### DIFF
--- a/game/blueprints.ts
+++ b/game/blueprints.ts
@@ -1,74 +1,133 @@
-
-import { BlueprintDB, StructureBlueprint, StrainBlueprint, DeviceBlueprint, CultivationMethodBlueprint, DevicePrice, Company, StrainPrice, UtilityPrices, PersonnelData, Trait, TaskDefinition, TaskType } from './types';
+import type {
+  BlueprintDB,
+  Company,
+  CultivationMethodBlueprint,
+  DeviceBlueprint,
+  PersonnelData,
+  StrainBlueprint,
+  StructureBlueprint,
+  TaskDefinition,
+  TaskType,
+} from './types';
 import {
-  assertHasString,
-  assertObject,
-  assertStringArray,
-  assertUniqueId,
-  validateCultivationMethodBlueprint,
-  validateDeviceBlueprint,
-  validateDevicePriceRecord,
-  validatePersonnelData,
-  validateStrainBlueprint,
-  validateStrainPriceRecord,
-  validateStructureBlueprint,
-  validateTaskDefinitions,
-  validateTraitList,
-  validateUtilityPrices,
+  BlueprintManifestSchema,
+  CultivationMethodBlueprintSchema,
+  DeviceBlueprintSchema,
+  DevicePricesFileSchema,
+  NameListSchema,
+  PersonnelDataSchema,
+  StrainBlueprintSchema,
+  StrainPricesFileSchema,
+  StructureBlueprintSchema,
+  TaskDefinitionsSchema,
+  TraitListSchema,
+  UtilityPricesSchema,
 } from '../src/game/blueprints/validation';
+import { formatZodError, parseJsonFile, tryParseJsonFile } from '../src/lib/staticJson';
+import type { ZodType } from 'zod';
+import { ZodError } from 'zod';
 
 const BLUEPRINT_BASE_PATH = '/data/blueprints/';
 const PERSONNEL_BASE_PATH = '/data/personnel/';
+const PRICES_BASE_PATH = '/data/prices/';
 const CONFIG_BASE_PATH = '/data/configs/';
+
+const DEFAULT_UTILITY_PRICES = {
+  pricePerKwh: 0.15,
+  pricePerLiterWater: 0.01,
+  pricePerGramNutrients: 0.1,
+};
 
 type BlueprintWithId = { id: string };
 
-// This type helps us model the structure of the JSON file.
-interface DevicePricesFile {
-  devicePrices: Record<string, DevicePrice>;
-}
+type BlueprintMap<T extends BlueprintWithId> = Record<string, T>;
 
-interface StrainPricesFile {
-  strainPrices: Record<string, StrainPrice>;
-}
+type BlueprintSchema<T extends BlueprintWithId> = ZodType<T>;
 
-type BlueprintValidator = (blueprint: Record<string, unknown>, context: string) => void;
-
-async function fetchAndStore<T extends BlueprintWithId>(
+function loadBlueprintCollection<T extends BlueprintWithId>(
   basePath: string,
-  files: string[],
-  store: Record<string, T>,
-  validator?: BlueprintValidator,
-): Promise<void> {
-  if (!files || files.length === 0) {
-    return;
+  fileNames: string[] | undefined,
+  schema: BlueprintSchema<T>,
+  errors: string[],
+): BlueprintMap<T> {
+  const collection: BlueprintMap<T> = {};
+  if (!fileNames || fileNames.length === 0) {
+    return collection;
   }
-  const promises = files.map(async (fileName) => {
-    const file = `${basePath}${fileName}`;
-    try {
-      const response = await fetch(file);
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      const json = await response.json();
-      if (!assertObject(json, file)) {
-        return;
-      }
-      if (!assertHasString(json, 'id', file)) {
-        return;
-      }
-      const context = `${file} (id=${json.id})`;
-      if (!assertUniqueId(store, json.id, context)) {
-        return;
-      }
-      validator?.(json, context);
-      store[json.id] = json as T;
-    } catch (e) {
-      console.error(`Failed to load blueprint: ${file}`, e);
-      throw e;
+
+  const idSources = new Map<string, string>();
+
+  fileNames.forEach((fileName) => {
+    const filePath = `${basePath}${fileName}`;
+    const blueprint = tryParseJsonFile(filePath, schema, errors);
+    if (!blueprint) {
+      return;
     }
+
+    const existingSource = idSources.get(blueprint.id);
+    if (existingSource) {
+      errors.push(`${filePath} → id → duplicate id '${blueprint.id}' also used in ${existingSource}`);
+      return;
+    }
+
+    idSources.set(blueprint.id, filePath);
+    collection[blueprint.id] = blueprint;
   });
-  await Promise.all(promises);
+
+  return collection;
+}
+
+function loadPersonnelData(fileNames: string[] | undefined, errors: string[]): PersonnelData {
+  const personnel: PersonnelData = {
+    firstNames: [],
+    lastNames: [],
+    traits: [],
+  };
+
+  if (!fileNames || fileNames.length === 0) {
+    return personnel;
+  }
+
+  fileNames.forEach((fileName) => {
+    const filePath = `${PERSONNEL_BASE_PATH}${fileName}`;
+    const normalized = fileName.toLowerCase();
+
+    if (normalized.includes('firstname')) {
+      const names = tryParseJsonFile(filePath, NameListSchema, errors);
+      if (names) {
+        personnel.firstNames = names;
+      }
+      return;
+    }
+
+    if (normalized.includes('lastname')) {
+      const names = tryParseJsonFile(filePath, NameListSchema, errors);
+      if (names) {
+        personnel.lastNames = names;
+      }
+      return;
+    }
+
+    if (normalized.includes('trait')) {
+      const traits = tryParseJsonFile(filePath, TraitListSchema, errors);
+      if (traits) {
+        personnel.traits = traits;
+      }
+      return;
+    }
+
+    errors.push(`${filePath} → <root> → unsupported personnel data file`);
+  });
+
+  try {
+    return PersonnelDataSchema.parse(personnel);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      errors.push(...formatZodError('personnelData', error));
+      return personnel;
+    }
+    throw error;
+  }
 }
 
 let blueprintDB: BlueprintDB | null = null;
@@ -76,179 +135,87 @@ let blueprintPromise: Promise<BlueprintDB> | null = null;
 
 export function getBlueprints(): BlueprintDB {
   if (!blueprintDB) {
-    throw new Error("Blueprints must be loaded before they can be accessed. Ensure loadAllBlueprints() has resolved.");
+    throw new Error('Blueprints must be loaded before they can be accessed. Ensure loadAllBlueprints() has resolved.');
   }
   return blueprintDB;
 }
 
 export function getAvailableStrains(company: Company): Record<string, StrainBlueprint> {
-    const baseStrains = getBlueprints().strains;
-    return {
-        ...baseStrains,
-        ...(company.customStrains || {}),
-    };
+  const baseStrains = getBlueprints().strains;
+  return {
+    ...baseStrains,
+    ...(company.customStrains || {}),
+  };
 }
 
 export function loadAllBlueprints(): Promise<BlueprintDB> {
   if (blueprintPromise) {
     return blueprintPromise;
   }
-  
-  blueprintPromise = (async () => {
-    // Fetch the central manifest file
-    const manifestResponse = await fetch(`${BLUEPRINT_BASE_PATH}manifest.json`);
-    if (!manifestResponse.ok) {
-        throw new Error("Could not fetch the blueprint manifest file.");
-    }
-    const manifest = await manifestResponse.json();
 
-    const structureFiles = manifest.structures || [];
-    const strainFiles = manifest.strains || [];
-    const deviceFiles = manifest.devices || [];
-    const cultivationMethodFiles = manifest.cultivationMethods || [];
-    const personnelFiles = manifest.personnel || {};
+  blueprintPromise = Promise.resolve()
+    .then(() => {
+      const manifest = parseJsonFile(`${BLUEPRINT_BASE_PATH}manifest.json`, BlueprintManifestSchema);
+      const errors: string[] = [];
 
-    const db: BlueprintDB = {
-      structures: {},
-      strains: {},
-      devices: {},
-      cultivationMethods: {},
-      devicePrices: {},
-      strainPrices: {},
-      utilityPrices: { pricePerKwh: 0.15, pricePerLiterWater: 0.01, pricePerGramNutrients: 0.10 },
-      personnelData: {
-        firstNames: [],
-        lastNames: [],
-        traits: [],
-      },
-      taskDefinitions: {} as Record<TaskType, TaskDefinition>,
-    };
-    
-    const devicePricesPromise = fetch('/data/prices/devicePrices.json')
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`HTTP error! status: ${res.status}`);
-        }
-        return res.json();
-      })
-      .then((data: DevicePricesFile) => {
-        const context = '/data/prices/devicePrices.json';
-        if (!assertObject(data, context)) {
-          return;
-        }
-        if (!assertObject(data.devicePrices, `${context}.devicePrices`)) {
-          return;
-        }
-        validateDevicePriceRecord(data.devicePrices, `${context}.devicePrices`);
-        db.devicePrices = data.devicePrices as Record<string, DevicePrice>;
-      }).catch(e => {
-        console.error("Failed to load device prices", e);
-        throw e;
-      });
+      const structures = loadBlueprintCollection<StructureBlueprint>(
+        `${BLUEPRINT_BASE_PATH}structures/`,
+        manifest.structures ?? [],
+        StructureBlueprintSchema,
+        errors,
+      );
 
-    const strainPricesPromise = fetch('/data/prices/strainPrices.json')
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`HTTP error! status: ${res.status}`);
-        }
-        return res.json();
-      })
-      .then((data: StrainPricesFile) => {
-        const context = '/data/prices/strainPrices.json';
-        if (!assertObject(data, context)) {
-          return;
-        }
-        if (!assertObject(data.strainPrices, `${context}.strainPrices`)) {
-          return;
-        }
-        validateStrainPriceRecord(data.strainPrices, `${context}.strainPrices`);
-        db.strainPrices = data.strainPrices as Record<string, StrainPrice>;
-      }).catch(e => {
-        console.error("Failed to load strain prices", e);
-        throw e;
-      });
+      const strains = loadBlueprintCollection<StrainBlueprint>(
+        `${BLUEPRINT_BASE_PATH}strains/`,
+        manifest.strains ?? [],
+        StrainBlueprintSchema,
+        errors,
+      );
 
-    const utilityPricesPromise = fetch('/data/prices/utilityPrices.json')
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`HTTP error! status: ${res.status}`);
-        }
-        return res.json();
-      })
-      .then((data: UtilityPrices) => {
-        const context = '/data/prices/utilityPrices.json';
-        if (validateUtilityPrices(data, context)) {
-          db.utilityPrices = data;
-        }
-      }).catch(e => {
-        console.error("Failed to load utility prices", e);
-        throw e;
-      });
+      const devices = loadBlueprintCollection<DeviceBlueprint>(
+        `${BLUEPRINT_BASE_PATH}devices/`,
+        manifest.devices ?? [],
+        DeviceBlueprintSchema,
+        errors,
+      );
 
-    const taskDefinitionsPromise = fetch(`${CONFIG_BASE_PATH}task_definitions.json`)
-        .then((res) => {
-            if (!res.ok) {
-                throw new Error(`HTTP error! status: ${res.status}`);
-            }
-            return res.json();
-        })
-        .then((data: Record<TaskType, TaskDefinition>) => {
-            const context = `${CONFIG_BASE_PATH}task_definitions.json`;
-            validateTaskDefinitions(data, context);
-            db.taskDefinitions = data;
-        }).catch(e => {
-            console.error("Failed to load task definitions", e);
-            throw e;
-        });
+      const cultivationMethods = loadBlueprintCollection<CultivationMethodBlueprint>(
+        `${BLUEPRINT_BASE_PATH}cultivationMethods/`,
+        manifest.cultivationMethods ?? [],
+        CultivationMethodBlueprintSchema,
+        errors,
+      );
 
-    // Load personnel data
-    const personnelPromises = Object.entries(personnelFiles).map(async ([, fileName]) => {
-        const filePath = `${PERSONNEL_BASE_PATH}${fileName}`;
-        try {
-            const response = await fetch(filePath);
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            const data = await response.json();
-            const dataKey = (fileName as string).replace('.json', '');
-            if (dataKey === 'firstNames') {
-                if (assertStringArray(data, filePath)) {
-                    db.personnelData.firstNames = data;
-                }
-            } else if (dataKey === 'lastNames') {
-                if (assertStringArray(data, filePath)) {
-                    db.personnelData.lastNames = data;
-                }
-            } else if (dataKey === 'traits') {
-                validateTraitList(data, filePath);
-                if (Array.isArray(data)) {
-                    db.personnelData.traits = data as Trait[];
-                }
-            }
-        } catch(e) {
-            console.error(`Failed to load personnel data: ${fileName}`, e);
-            throw e;
-        }
+      const personnelData = loadPersonnelData(manifest.personnel ?? [], errors);
+
+      const devicePricesData = tryParseJsonFile(`${PRICES_BASE_PATH}devicePrices.json`, DevicePricesFileSchema, errors);
+      const strainPricesData = tryParseJsonFile(`${PRICES_BASE_PATH}strainPrices.json`, StrainPricesFileSchema, errors);
+      const utilityPrices = tryParseJsonFile(`${PRICES_BASE_PATH}utilityPrices.json`, UtilityPricesSchema, errors);
+      const taskDefinitions = tryParseJsonFile(`${CONFIG_BASE_PATH}task_definitions.json`, TaskDefinitionsSchema, errors);
+
+      if (errors.length > 0) {
+        throw new Error(`Blueprint validation failed:\n${errors.join('\n')}`);
+      }
+
+      const db: BlueprintDB = {
+        structures,
+        strains,
+        devices,
+        cultivationMethods,
+        devicePrices: devicePricesData?.devicePrices ?? {},
+        strainPrices: strainPricesData?.strainPrices ?? {},
+        utilityPrices: utilityPrices ?? DEFAULT_UTILITY_PRICES,
+        personnelData,
+        taskDefinitions: (taskDefinitions ?? {}) as Record<TaskType, TaskDefinition>,
+      };
+
+      blueprintDB = db;
+      return db;
+    })
+    .catch((error) => {
+      blueprintPromise = null;
+      throw error;
     });
-
-    // Load all blueprints based on the manifest
-    await Promise.all([
-      fetchAndStore<StructureBlueprint>(`${BLUEPRINT_BASE_PATH}structures/`, structureFiles, db.structures, validateStructureBlueprint),
-      fetchAndStore<StrainBlueprint>(`${BLUEPRINT_BASE_PATH}strains/`, strainFiles, db.strains, validateStrainBlueprint),
-      fetchAndStore<DeviceBlueprint>(`${BLUEPRINT_BASE_PATH}devices/`, deviceFiles, db.devices, validateDeviceBlueprint),
-      fetchAndStore<CultivationMethodBlueprint>(`${BLUEPRINT_BASE_PATH}cultivationMethods/`, cultivationMethodFiles, db.cultivationMethods, validateCultivationMethodBlueprint),
-      devicePricesPromise,
-      strainPricesPromise,
-      utilityPricesPromise,
-      taskDefinitionsPromise,
-      ...personnelPromises,
-    ]);
-    
-    validatePersonnelData(db.personnelData, 'personnelData');
-
-    blueprintDB = db;
-    return db;
-  })();
 
   return blueprintPromise;
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/src/game/blueprints/validation.ts
+++ b/src/game/blueprints/validation.ts
@@ -1,359 +1,253 @@
-const VALIDATION_PREFIX = '[Blueprint validation]';
+import { z } from 'zod';
+import type {
+  CultivationMethodBlueprint,
+  DeviceBlueprint,
+  DevicePrice,
+  PersonnelData,
+  StrainBlueprint,
+  StrainPrice,
+  StructureBlueprint,
+  TaskDefinition,
+  Trait,
+  UtilityPrices,
+} from '@/game/types';
+import type { JobRole, SkillName } from '@/game/types';
 
-function describeValue(value: unknown): string {
-  if (value === null) {
-    return 'null';
-  }
-  if (Array.isArray(value)) {
-    return 'array';
-  }
-  return typeof value;
-}
+const StageRangeTupleSchema = z.tuple([z.number(), z.number()]);
+const StageRangeRecordSchema = z.record(StageRangeTupleSchema);
+const NutrientDemandSchema = z.record(z.record(z.number()));
+const WaterDemandSchema = z.object({
+  dailyWaterUsagePerSquareMeter: z.record(z.number()),
+}).passthrough();
 
-function warn(context: string, message: string): void {
-  console.warn(`${VALIDATION_PREFIX} ${context}: ${message}`);
-}
+export const StructureBlueprintSchema: z.ZodType<StructureBlueprint> = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    footprint: z
+      .object({
+        length_m: z.number(),
+        width_m: z.number(),
+        height_m: z.number(),
+      })
+      .passthrough(),
+    rentalCostPerSqmPerMonth: z.number(),
+    upfrontFee: z.number(),
+  })
+  .passthrough();
 
-export function assertObject(value: unknown, context: string): value is Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    warn(context, `Expected an object but received ${describeValue(value)}.`);
-    return false;
-  }
-  return true;
-}
+export const StrainBlueprintSchema: z.ZodType<StrainBlueprint> = z
+  .object({
+    id: z.string(),
+    slug: z.string(),
+    name: z.string(),
+    lineage: z
+      .object({
+        parents: z.array(z.string()),
+      })
+      .passthrough(),
+    genotype: z
+      .object({
+        sativa: z.number(),
+        indica: z.number(),
+        ruderalis: z.number(),
+      })
+      .passthrough(),
+    generalResilience: z.number(),
+    germinationRate: z.number().optional(),
+    chemotype: z
+      .object({
+        thcContent: z.number(),
+        cbdContent: z.number(),
+      })
+      .passthrough(),
+    morphology: z
+      .object({
+        growthRate: z.number(),
+        yieldFactor: z.number(),
+        leafAreaIndex: z.number(),
+      })
+      .passthrough(),
+    growthModel: z.object({ maxBiomassDry_g: z.number() }).passthrough(),
+    noise: z
+      .object({
+        enabled: z.boolean(),
+        pct: z.number(),
+      })
+      .passthrough()
+      .optional(),
+    environmentalPreferences: z
+      .object({
+        idealTemperature: StageRangeRecordSchema,
+        lightIntensity: StageRangeRecordSchema,
+        idealHumidity: StageRangeRecordSchema,
+        lightCycle: StageRangeRecordSchema,
+      })
+      .passthrough(),
+    waterDemand: WaterDemandSchema,
+    nutrientDemand: z
+      .object({
+        dailyNutrientDemand: NutrientDemandSchema,
+      })
+      .passthrough(),
+    photoperiod: z
+      .object({
+        vegetationDays: z.number(),
+        floweringDays: z.number(),
+        transitionTriggerHours: z.number(),
+      })
+      .passthrough(),
+    harvestWindowInDays: StageRangeTupleSchema,
+    meta: z
+      .object({
+        description: z.string(),
+        advantages: z.array(z.string()),
+        disadvantages: z.array(z.string()),
+        notes: z.string(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
 
-export function assertArray(value: unknown, context: string): value is unknown[] {
-  if (!Array.isArray(value)) {
-    warn(context, `Expected an array but received ${describeValue(value)}.`);
-    return false;
-  }
-  return true;
-}
+const DeviceSettingsSchema = z
+  .object({
+    coverageArea: z.number().optional(),
+    ppfd: z.number().optional(),
+    airflow: z.number().optional(),
+  })
+  .catchall(z.unknown());
 
-export function assertStringArray(value: unknown, context: string): value is string[] {
-  if (!assertArray(value, context)) {
-    return false;
-  }
-  let valid = true;
-  value.forEach((entry, index) => {
-    if (typeof entry !== 'string') {
-      warn(`${context}[${index}]`, `Expected a string but received ${describeValue(entry)}.`);
-      valid = false;
-    }
-  });
-  return valid;
-}
+export const DeviceBlueprintSchema: z.ZodType<DeviceBlueprint> = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    kind: z.string(),
+    settings: DeviceSettingsSchema.optional(),
+  })
+  .passthrough();
 
-export function assertNumberTuple(value: unknown, length: number, context: string): value is number[] {
-  if (!assertArray(value, context)) {
-    return false;
-  }
-  if (value.length !== length) {
-    warn(context, `Expected an array of length ${length} but received ${value.length}.`);
-  }
-  let valid = true;
-  value.forEach((entry, index) => {
-    if (typeof entry !== 'number' || Number.isNaN(entry)) {
-      warn(`${context}[${index}]`, `Expected a finite number but received ${describeValue(entry)}.`);
-      valid = false;
-    }
-  });
-  return valid;
-}
+const TraitBoundsSchema = z
+  .object({
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .partial();
 
-export function assertHasString<T extends Record<string, unknown>, K extends string>(
-  obj: T,
-  field: K,
-  context: string,
-): obj is T & Record<K, string> {
-  const value = obj[field];
-  if (typeof value !== 'string') {
-    warn(context, `Expected '${field}' to be a string but received ${describeValue(value)}.`);
-    return false;
-  }
-  return true;
-}
+const TraitCompatibilitySchema = z
+  .object({
+    preferred: z.record(TraitBoundsSchema).optional(),
+    conflicting: z.record(TraitBoundsSchema).optional(),
+  })
+  .partial()
+  .passthrough();
 
-export function assertHasNumber<T extends Record<string, unknown>, K extends string>(
-  obj: T,
-  field: K,
-  context: string,
-): obj is T & Record<K, number> {
-  const value = obj[field];
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    warn(context, `Expected '${field}' to be a finite number but received ${describeValue(value)}.`);
-    return false;
-  }
-  return true;
-}
+export const CultivationMethodBlueprintSchema: z.ZodType<CultivationMethodBlueprint> = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    kind: z.string(),
+    areaPerPlant: z.number(),
+    setupCost: z.number(),
+    maxCycles: z.number(),
+    strainTraitCompatibility: TraitCompatibilitySchema.optional(),
+  })
+  .passthrough();
 
-export function assertOptionalNumber<T extends Record<string, unknown>, K extends string>(
-  obj: T,
-  field: K,
-  context: string,
-): boolean {
-  if (obj[field] === undefined) {
-    return true;
-  }
-  return assertHasNumber(obj, field, context);
-}
+export const DevicePriceSchema: z.ZodType<DevicePrice> = z
+  .object({
+    capitalExpenditure: z.number(),
+    baseMaintenanceCostPerTick: z.number(),
+    costIncreasePer1000Ticks: z.number(),
+  })
+  .strict();
 
-export function assertBoolean(value: unknown, context: string): value is boolean {
-  if (typeof value !== 'boolean') {
-    warn(context, `Expected a boolean but received ${describeValue(value)}.`);
-    return false;
-  }
-  return true;
-}
+export const DevicePricesFileSchema = z.object({
+  devicePrices: z.record(DevicePriceSchema),
+});
 
-export function assertUniqueId<T>(store: Record<string, T>, id: string, context: string): boolean {
-  if (store[id]) {
-    warn(context, `Duplicate id '${id}' encountered. Keeping the first occurrence.`);
-    return false;
-  }
-  return true;
-}
+export const StrainPriceSchema: z.ZodType<StrainPrice> = z
+  .object({
+    seedPrice: z.number(),
+    harvestPricePerGram: z.number(),
+  })
+  .strict();
 
-const STAGE_KEYS = ['vegetation', 'flowering'] as const;
+export const StrainPricesFileSchema = z.object({
+  strainPrices: z.record(StrainPriceSchema),
+});
 
-function validateStageRanges(value: unknown, context: string): void {
-  if (!assertObject(value, context)) {
-    return;
-  }
-  STAGE_KEYS.forEach((stage) => {
-    assertNumberTuple(value[stage], 2, `${context}.${stage}`);
-  });
-}
+export const UtilityPricesSchema: z.ZodType<UtilityPrices> = z
+  .object({
+    pricePerKwh: z.number(),
+    pricePerLiterWater: z.number(),
+    pricePerGramNutrients: z.number(),
+  })
+  .strict();
 
-export function validateStructureBlueprint(blueprint: Record<string, unknown>, context: string): void {
-  assertHasString(blueprint, 'name', `${context}.name`);
-  assertHasNumber(blueprint, 'rentalCostPerSqmPerMonth', `${context}.rentalCostPerSqmPerMonth`);
-  assertHasNumber(blueprint, 'upfrontFee', `${context}.upfrontFee`);
+export const TraitSchema: z.ZodType<Trait> = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    type: z.union([z.literal('positive'), z.literal('negative')]),
+    effects: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
 
-  if (assertObject(blueprint.footprint, `${context}.footprint`)) {
-    assertHasNumber(blueprint.footprint, 'length_m', `${context}.footprint.length_m`);
-    assertHasNumber(blueprint.footprint, 'width_m', `${context}.footprint.width_m`);
-    assertHasNumber(blueprint.footprint, 'height_m', `${context}.footprint.height_m`);
-  }
-}
+export const TraitListSchema = z.array(TraitSchema);
 
-export function validateStrainBlueprint(blueprint: Record<string, unknown>, context: string): void {
-  assertHasString(blueprint, 'slug', `${context}.slug`);
-  assertHasString(blueprint, 'name', `${context}.name`);
-  assertHasNumber(blueprint, 'generalResilience', `${context}.generalResilience`);
-  assertOptionalNumber(blueprint, 'germinationRate', `${context}.germinationRate`);
+export const PersonnelDataSchema: z.ZodType<PersonnelData> = z.object({
+  firstNames: z.array(z.string()),
+  lastNames: z.array(z.string()),
+  traits: TraitListSchema,
+});
 
-  if (assertObject(blueprint.lineage, `${context}.lineage`)) {
-    assertStringArray(blueprint.lineage.parents, `${context}.lineage.parents`);
-  }
+export const BlueprintManifestSchema = z
+  .object({
+    structures: z.array(z.string()).optional(),
+    strains: z.array(z.string()).optional(),
+    devices: z.array(z.string()).optional(),
+    cultivationMethods: z.array(z.string()).optional(),
+    personnel: z.array(z.string()).optional(),
+  })
+  .passthrough();
 
-  if (assertObject(blueprint.genotype, `${context}.genotype`)) {
-    assertHasNumber(blueprint.genotype, 'sativa', `${context}.genotype.sativa`);
-    assertHasNumber(blueprint.genotype, 'indica', `${context}.genotype.indica`);
-    assertHasNumber(blueprint.genotype, 'ruderalis', `${context}.genotype.ruderalis`);
-  }
+const CostBasisSchema = z.enum(['perAction', 'perPlant', 'perSquareMeter']);
 
-  if (assertObject(blueprint.chemotype, `${context}.chemotype`)) {
-    assertHasNumber(blueprint.chemotype, 'thcContent', `${context}.chemotype.thcContent`);
-    assertHasNumber(blueprint.chemotype, 'cbdContent', `${context}.chemotype.cbdContent`);
-  }
+const JobRoleSchema: z.ZodType<JobRole> = z.enum([
+  'Gardener',
+  'Technician',
+  'Janitor',
+  'Botanist',
+  'Salesperson',
+  'Generalist',
+] as const);
 
-  if (assertObject(blueprint.morphology, `${context}.morphology`)) {
-    assertHasNumber(blueprint.morphology, 'growthRate', `${context}.morphology.growthRate`);
-    assertHasNumber(blueprint.morphology, 'yieldFactor', `${context}.morphology.yieldFactor`);
-    assertHasNumber(blueprint.morphology, 'leafAreaIndex', `${context}.morphology.leafAreaIndex`);
-  }
+const SkillNameSchema: z.ZodType<SkillName> = z.enum([
+  'Gardening',
+  'Maintenance',
+  'Technical',
+  'Botanical',
+  'Cleanliness',
+  'Negotiation',
+] as const);
 
-  if (assertObject(blueprint.growthModel, `${context}.growthModel`)) {
-    assertHasNumber(blueprint.growthModel, 'maxBiomassDry_g', `${context}.growthModel.maxBiomassDry_g`);
-  }
+export const TaskDefinitionSchema: z.ZodType<TaskDefinition> = z
+  .object({
+    costModel: z
+      .object({
+        basis: CostBasisSchema,
+        laborMinutes: z.number(),
+      })
+      .passthrough(),
+    priority: z.number(),
+    requiredRole: JobRoleSchema,
+    minSkillLevel: z.number(),
+    requiredSkill: SkillNameSchema,
+    description: z.string(),
+  })
+  .passthrough();
 
-  if (assertObject(blueprint.environmentalPreferences, `${context}.environmentalPreferences`)) {
-    validateStageRanges(blueprint.environmentalPreferences.idealTemperature, `${context}.environmentalPreferences.idealTemperature`);
-    validateStageRanges(blueprint.environmentalPreferences.lightIntensity, `${context}.environmentalPreferences.lightIntensity`);
-    validateStageRanges(blueprint.environmentalPreferences.idealHumidity, `${context}.environmentalPreferences.idealHumidity`);
-    validateStageRanges(blueprint.environmentalPreferences.lightCycle, `${context}.environmentalPreferences.lightCycle`);
-  }
+export const TaskDefinitionsSchema = z.record(TaskDefinitionSchema);
 
-  if (assertObject(blueprint.waterDemand, `${context}.waterDemand`)) {
-    if (assertObject(blueprint.waterDemand.dailyWaterUsagePerSquareMeter, `${context}.waterDemand.dailyWaterUsagePerSquareMeter`)) {
-      Object.entries(blueprint.waterDemand.dailyWaterUsagePerSquareMeter).forEach(([stage, amount]) => {
-        if (typeof amount !== 'number' || Number.isNaN(amount)) {
-          warn(`${context}.waterDemand.dailyWaterUsagePerSquareMeter.${stage}`, `Expected a finite number but received ${describeValue(amount)}.`);
-        }
-      });
-    }
-  }
-
-  if (assertObject(blueprint.nutrientDemand, `${context}.nutrientDemand`)) {
-    if (assertObject(blueprint.nutrientDemand.dailyNutrientDemand, `${context}.nutrientDemand.dailyNutrientDemand`)) {
-      Object.entries(blueprint.nutrientDemand.dailyNutrientDemand).forEach(([stage, nutrients]) => {
-        if (assertObject(nutrients, `${context}.nutrientDemand.dailyNutrientDemand.${stage}`)) {
-          Object.entries(nutrients).forEach(([nutrient, amount]) => {
-            if (typeof amount !== 'number' || Number.isNaN(amount)) {
-              warn(`${context}.nutrientDemand.dailyNutrientDemand.${stage}.${nutrient}`, `Expected a finite number but received ${describeValue(amount)}.`);
-            }
-          });
-        }
-      });
-    }
-  }
-
-  if (assertObject(blueprint.photoperiod, `${context}.photoperiod`)) {
-    assertHasNumber(blueprint.photoperiod, 'vegetationDays', `${context}.photoperiod.vegetationDays`);
-    assertHasNumber(blueprint.photoperiod, 'floweringDays', `${context}.photoperiod.floweringDays`);
-    assertHasNumber(blueprint.photoperiod, 'transitionTriggerHours', `${context}.photoperiod.transitionTriggerHours`);
-  }
-
-  assertNumberTuple(blueprint.harvestWindowInDays, 2, `${context}.harvestWindowInDays`);
-
-  if (assertObject(blueprint.meta, `${context}.meta`)) {
-    assertHasString(blueprint.meta, 'description', `${context}.meta.description`);
-    if (assertArray(blueprint.meta.advantages, `${context}.meta.advantages`)) {
-      blueprint.meta.advantages.forEach((entry, index) => {
-        if (typeof entry !== 'string') {
-          warn(`${context}.meta.advantages[${index}]`, `Expected a string but received ${describeValue(entry)}.`);
-        }
-      });
-    }
-    if (assertArray(blueprint.meta.disadvantages, `${context}.meta.disadvantages`)) {
-      blueprint.meta.disadvantages.forEach((entry, index) => {
-        if (typeof entry !== 'string') {
-          warn(`${context}.meta.disadvantages[${index}]`, `Expected a string but received ${describeValue(entry)}.`);
-        }
-      });
-    }
-    assertHasString(blueprint.meta, 'notes', `${context}.meta.notes`);
-  }
-
-  if (blueprint.noise !== undefined && blueprint.noise !== null) {
-    if (assertObject(blueprint.noise, `${context}.noise`)) {
-      const enabled = blueprint.noise.enabled;
-      if (enabled !== undefined) {
-        assertBoolean(enabled, `${context}.noise.enabled`);
-      }
-      assertOptionalNumber(blueprint.noise, 'pct', `${context}.noise.pct`);
-    }
-  }
-}
-
-export function validateDeviceBlueprint(blueprint: Record<string, unknown>, context: string): void {
-  assertHasString(blueprint, 'name', `${context}.name`);
-  assertHasString(blueprint, 'kind', `${context}.kind`);
-
-  if (blueprint.settings !== undefined && blueprint.settings !== null) {
-    if (assertObject(blueprint.settings, `${context}.settings`)) {
-      ['coverageArea', 'ppfd', 'airflow'].forEach((field) => {
-        assertOptionalNumber(blueprint.settings, field, `${context}.settings.${field}`);
-      });
-    }
-  }
-}
-
-export function validateCultivationMethodBlueprint(blueprint: Record<string, unknown>, context: string): void {
-  assertHasString(blueprint, 'name', `${context}.name`);
-  assertHasString(blueprint, 'kind', `${context}.kind`);
-  assertHasNumber(blueprint, 'areaPerPlant', `${context}.areaPerPlant`);
-  assertHasNumber(blueprint, 'setupCost', `${context}.setupCost`);
-  assertHasNumber(blueprint, 'maxCycles', `${context}.maxCycles`);
-
-  if (blueprint.strainTraitCompatibility !== undefined && blueprint.strainTraitCompatibility !== null) {
-    if (assertObject(blueprint.strainTraitCompatibility, `${context}.strainTraitCompatibility`)) {
-      ['preferred', 'conflicting'].forEach((section) => {
-        const value = blueprint.strainTraitCompatibility?.[section as 'preferred' | 'conflicting'];
-        if (value !== undefined) {
-          if (assertObject(value, `${context}.strainTraitCompatibility.${section}`)) {
-            Object.entries(value).forEach(([trait, bounds]) => {
-              if (bounds !== undefined && bounds !== null && assertObject(bounds, `${context}.strainTraitCompatibility.${section}.${trait}`)) {
-                assertOptionalNumber(bounds, 'min', `${context}.strainTraitCompatibility.${section}.${trait}.min`);
-                assertOptionalNumber(bounds, 'max', `${context}.strainTraitCompatibility.${section}.${trait}.max`);
-              }
-            });
-          }
-        }
-      });
-    }
-  }
-}
-
-export function validateDevicePriceRecord(record: Record<string, unknown>, context: string): void {
-  Object.entries(record).forEach(([deviceId, value]) => {
-    if (!assertObject(value, `${context}.${deviceId}`)) {
-      return;
-    }
-    assertHasNumber(value, 'capitalExpenditure', `${context}.${deviceId}.capitalExpenditure`);
-    assertHasNumber(value, 'baseMaintenanceCostPerTick', `${context}.${deviceId}.baseMaintenanceCostPerTick`);
-    assertHasNumber(value, 'costIncreasePer1000Ticks', `${context}.${deviceId}.costIncreasePer1000Ticks`);
-  });
-}
-
-export function validateStrainPriceRecord(record: Record<string, unknown>, context: string): void {
-  Object.entries(record).forEach(([strainId, value]) => {
-    if (!assertObject(value, `${context}.${strainId}`)) {
-      return;
-    }
-    assertHasNumber(value, 'seedPrice', `${context}.${strainId}.seedPrice`);
-    assertHasNumber(value, 'harvestPricePerGram', `${context}.${strainId}.harvestPricePerGram`);
-  });
-}
-
-export function validateUtilityPrices(value: unknown, context: string): value is Record<string, unknown> {
-  if (!assertObject(value, context)) {
-    return false;
-  }
-  assertHasNumber(value, 'pricePerKwh', `${context}.pricePerKwh`);
-  assertHasNumber(value, 'pricePerLiterWater', `${context}.pricePerLiterWater`);
-  assertHasNumber(value, 'pricePerGramNutrients', `${context}.pricePerGramNutrients`);
-  return true;
-}
-
-export function validateTraitList(value: unknown, context: string): void {
-  if (!assertArray(value, context)) {
-    return;
-  }
-  value.forEach((trait, index) => {
-    if (!assertObject(trait, `${context}[${index}]`)) {
-      return;
-    }
-    assertHasString(trait, 'id', `${context}[${index}].id`);
-    assertHasString(trait, 'name', `${context}[${index}].name`);
-    assertHasString(trait, 'description', `${context}[${index}].description`);
-    const type = trait.type;
-    if (type !== undefined) {
-      if (typeof type !== 'string') {
-        warn(`${context}[${index}].type`, `Expected a string but received ${describeValue(type)}.`);
-      } else if (type !== 'positive' && type !== 'negative') {
-        warn(`${context}[${index}].type`, `Unexpected value '${type}'. Expected 'positive' or 'negative'.`);
-      }
-    }
-  });
-}
-
-export function validatePersonnelData(value: unknown, context: string): void {
-  if (!assertObject(value, context)) {
-    return;
-  }
-  assertStringArray(value.firstNames, `${context}.firstNames`);
-  assertStringArray(value.lastNames, `${context}.lastNames`);
-  validateTraitList(value.traits, `${context}.traits`);
-}
-
-export function validateTaskDefinitions(record: unknown, context: string): void {
-  if (!assertObject(record, context)) {
-    return;
-  }
-  Object.entries(record).forEach(([taskType, definition]) => {
-    if (!assertObject(definition, `${context}.${taskType}`)) {
-      return;
-    }
-    if (assertObject(definition.costModel, `${context}.${taskType}.costModel`)) {
-      assertHasString(definition.costModel, 'basis', `${context}.${taskType}.costModel.basis`);
-      assertHasNumber(definition.costModel, 'laborMinutes', `${context}.${taskType}.costModel.laborMinutes`);
-    }
-    assertHasNumber(definition, 'priority', `${context}.${taskType}.priority`);
-    assertHasString(definition, 'requiredRole', `${context}.${taskType}.requiredRole`);
-    assertHasNumber(definition, 'minSkillLevel', `${context}.${taskType}.minSkillLevel`);
-    assertHasString(definition, 'requiredSkill', `${context}.${taskType}.requiredSkill`);
-    assertHasString(definition, 'description', `${context}.${taskType}.description`);
-  });
-}
+export const NameListSchema = z.array(z.string());

--- a/src/game/health/loader.ts
+++ b/src/game/health/loader.ts
@@ -1,48 +1,96 @@
-import type {
-  DiseaseBalancingConfig,
-  HealthDefinitionData,
-  HealthDefinitionSummary,
-  PestBalancingConfig,
-  TreatmentCatalog,
-  TreatmentOption,
-} from './types';
+import type { HealthDefinitionData, HealthDefinitionSummary, TreatmentOption } from './types';
+import {
+  DiseaseBalancingConfigSchema,
+  DiseaseDefinitionSchema,
+  PestBalancingConfigSchema,
+  PestDefinitionSchema,
+  TreatmentCatalogSchema,
+} from './schemas';
+import { listJsonFiles, tryParseJsonFile } from '@/src/lib/staticJson';
+import type { ZodType } from 'zod';
 
 const DISEASE_CONFIG_URL = '/data/configs/disease_balancing.json';
 const PEST_CONFIG_URL = '/data/configs/pest_balancing.json';
 const TREATMENT_CONFIG_URL = '/data/configs/treatment_options.json';
+const DISEASE_BLUEPRINT_DIR = '/data/blueprints/diseases/';
+const PEST_BLUEPRINT_DIR = '/data/blueprints/pests/';
+
+type Identified = { id: string };
+
+type DefinitionSchema<T extends Identified> = ZodType<T>;
+
+function loadDefinitions<T extends Identified>(
+  directory: string,
+  schema: DefinitionSchema<T>,
+  errors: string[],
+): T[] {
+  const definitions: T[] = [];
+  const idSources = new Map<string, string>();
+
+  const files = listJsonFiles(directory);
+
+  files.forEach((filePath) => {
+    const definition = tryParseJsonFile(filePath, schema, errors);
+    if (!definition) {
+      return;
+    }
+
+    const existing = idSources.get(definition.id);
+    if (existing) {
+      errors.push(`${filePath} → id → duplicate id '${definition.id}' also used in ${existing}`);
+      return;
+    }
+
+    idSources.set(definition.id, filePath);
+    definitions.push(definition);
+  });
+
+  return definitions;
+}
 
 let memory: HealthDefinitionData | null = null;
 let loadPromise: Promise<HealthDefinitionData> | null = null;
 
-async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to load health config from ${url}: ${response.status} ${response.statusText}`);
-  }
-  return (await response.json()) as T;
-}
+function load(): HealthDefinitionData {
+  const errors: string[] = [];
 
-async function load(): Promise<HealthDefinitionData> {
-  const [diseaseBalancing, pestBalancing, treatmentCatalog] = await Promise.all([
-    fetchJson<DiseaseBalancingConfig>(DISEASE_CONFIG_URL),
-    fetchJson<PestBalancingConfig>(PEST_CONFIG_URL),
-    fetchJson<TreatmentCatalog>(TREATMENT_CONFIG_URL),
-  ]);
+  const diseaseBalancing = tryParseJsonFile(DISEASE_CONFIG_URL, DiseaseBalancingConfigSchema, errors);
+  const pestBalancing = tryParseJsonFile(PEST_CONFIG_URL, PestBalancingConfigSchema, errors);
+  const treatmentCatalog = tryParseJsonFile(TREATMENT_CONFIG_URL, TreatmentCatalogSchema, errors);
+
+  const diseases = loadDefinitions(DISEASE_BLUEPRINT_DIR, DiseaseDefinitionSchema, errors);
+  const pests = loadDefinitions(PEST_BLUEPRINT_DIR, PestDefinitionSchema, errors);
+
+  if (!diseaseBalancing) {
+    throw new Error(`Health data validation failed:\n${errors.join('\n')}`);
+  }
+  if (!pestBalancing) {
+    throw new Error(`Health data validation failed:\n${errors.join('\n')}`);
+  }
+  if (!treatmentCatalog) {
+    throw new Error(`Health data validation failed:\n${errors.join('\n')}`);
+  }
+  if (errors.length > 0) {
+    throw new Error(`Health data validation failed:\n${errors.join('\n')}`);
+  }
 
   return {
     diseaseBalancing,
     pestBalancing,
     treatmentCatalog,
+    diseases,
+    pests,
   };
 }
 
-export async function loadHealthData(): Promise<HealthDefinitionData> {
+export function loadAllHealthData(): Promise<HealthDefinitionData> {
   if (memory) {
-    return memory;
+    return Promise.resolve(memory);
   }
 
   if (!loadPromise) {
-    loadPromise = load()
+    loadPromise = Promise.resolve()
+      .then(() => load())
       .then((result) => {
         memory = result;
         return result;
@@ -56,27 +104,28 @@ export async function loadHealthData(): Promise<HealthDefinitionData> {
   return loadPromise;
 }
 
-export async function ensureHealthData(): Promise<HealthDefinitionData> {
-  if (memory) {
-    return memory;
-  }
-  return loadHealthData();
+export function loadHealthData(): Promise<HealthDefinitionData> {
+  return loadAllHealthData();
+}
+
+export function ensureHealthData(): Promise<HealthDefinitionData> {
+  return loadAllHealthData();
 }
 
 export function getHealthData(): HealthDefinitionData {
   if (!memory) {
-    throw new Error('Health definitions are not loaded yet. Call loadHealthData() first.');
+    throw new Error('Health definitions are not loaded yet. Call loadAllHealthData() first.');
   }
   return memory;
 }
 
 export async function listTreatmentOptions(): Promise<TreatmentOption[]> {
-  const data = await ensureHealthData();
+  const data = await loadAllHealthData();
   return data.treatmentCatalog.options;
 }
 
 export async function listHealthDefinitions(): Promise<HealthDefinitionSummary> {
-  const data = await ensureHealthData();
+  const data = await loadAllHealthData();
   return {
     diseases: data.diseaseBalancing,
     pests: data.pestBalancing,

--- a/src/game/health/schemas.ts
+++ b/src/game/health/schemas.ts
@@ -1,0 +1,295 @@
+import { z } from 'zod';
+import type {
+  DiseaseBalancingConfig,
+  DiseaseDefinition,
+  DiseaseTreatmentEfficacy,
+  PestBalancingConfig,
+  PestDefinition,
+  PestTreatmentEfficacy,
+  TreatmentCatalog,
+  TreatmentOption,
+} from './types';
+
+const NumericTupleSchema = z.tuple([z.number(), z.number()]);
+const RangeDescriptorSchema = z.object({ min: z.number(), max: z.number() }).strict();
+
+export const DiseaseTreatmentEfficacySchema: z.ZodType<DiseaseTreatmentEfficacy> = z
+  .object({
+    infectionMultiplier: z.number().optional(),
+    degenerationMultiplier: z.number().optional(),
+    recoveryMultiplier: z.number().optional(),
+  })
+  .passthrough();
+
+export const PestTreatmentEfficacySchema: z.ZodType<PestTreatmentEfficacy> = z
+  .object({
+    reproductionMultiplier: z.number().optional(),
+    mortalityMultiplier: z.number().optional(),
+    damageMultiplier: z.number().optional(),
+  })
+  .passthrough();
+
+const TreatmentCostsSchema = z
+  .object({
+    laborMinutes: z.number().optional(),
+    materialsCost: z.number().optional(),
+    energyPerHourKWh: z.number().optional(),
+    equipmentRentalEUR: z.number().optional(),
+  })
+  .catchall(z.number().optional());
+
+const TreatmentRisksSchema = z.record(z.union([z.string(), z.boolean(), z.number()])).optional();
+
+const TreatmentEfficacySchema = z
+  .object({
+    disease: DiseaseTreatmentEfficacySchema.optional(),
+    pest: PestTreatmentEfficacySchema.optional(),
+  })
+  .catchall(z.union([DiseaseTreatmentEfficacySchema, PestTreatmentEfficacySchema]));
+
+const TreatmentStackingRulesSchema = z
+  .object({
+    maxConcurrentTreatmentsPerZone: z.number(),
+    mechanicalAlwaysStacks: z.boolean(),
+    chemicalAndBiologicalCantShareSameMoAWithin7Days: z.boolean(),
+    cooldownDaysDefault: z.number(),
+  })
+  .passthrough();
+
+const TreatmentSideEffectsSchema = z
+  .object({
+    phytotoxicityRiskKeys: z.array(z.string()),
+    beneficialsHarmRiskKeys: z.array(z.string()),
+  })
+  .catchall(z.array(z.string()).optional());
+
+const TreatmentCostBasisDescriptionsSchema = z
+  .object({
+    perZone: z.string().optional(),
+    perPlant: z.string().optional(),
+    perSquareMeter: z.string().optional(),
+  })
+  .catchall(z.string().optional());
+
+const TreatmentCostModelInfoSchema = z
+  .object({
+    costBasis: TreatmentCostBasisDescriptionsSchema,
+    totalCostFormula: z.string(),
+  })
+  .passthrough();
+
+const TreatmentGlobalConfigSchema = z
+  .object({
+    stackingRules: TreatmentStackingRulesSchema,
+    sideEffects: TreatmentSideEffectsSchema,
+    costModel: TreatmentCostModelInfoSchema,
+  })
+  .passthrough();
+
+export const TreatmentOptionSchema: z.ZodType<TreatmentOption> = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    category: z.string(),
+    targets: z.array(z.string()),
+    applicability: z.array(z.string()),
+    efficacy: TreatmentEfficacySchema,
+    costs: TreatmentCostsSchema,
+    cooldownDays: z.number(),
+    notes: z.string().optional(),
+    costBasis: z.string(),
+    risks: TreatmentRisksSchema,
+  })
+  .passthrough();
+
+export const TreatmentCatalogSchema: z.ZodType<TreatmentCatalog> = z
+  .object({
+    kind: z.string(),
+    version: z.string(),
+    notes: z.string().optional(),
+    global: TreatmentGlobalConfigSchema,
+    options: z.array(TreatmentOptionSchema),
+  })
+  .passthrough();
+
+const DiseaseBalancingGlobalConfigSchema = z
+  .object({
+    baseDailyInfectionMultiplier: z.number(),
+    baseRecoveryMultiplier: z.number(),
+    maxConcurrentDiseases: z.number(),
+    symptomDelayDays: RangeDescriptorSchema,
+    eventWeights: z.record(z.number()),
+  })
+  .passthrough();
+
+const DiseasePhaseMultipliersSchema = z
+  .object({
+    infection: z.number().optional(),
+    degeneration: z.number().optional(),
+    recovery: z.number().optional(),
+  })
+  .passthrough();
+
+const DiseaseEnvironmentModifierSchema = z.record(
+  z.union([NumericTupleSchema, z.number(), z.boolean(), z.string()]),
+);
+
+const DiseaseStrainResistanceWeightsSchema = z
+  .object({
+    generalResilienceWeight: z.number().optional(),
+    specificResistanceWeight: z.number().optional(),
+  })
+  .catchall(z.number().optional());
+
+const DiseaseCapsSchema = z
+  .object({
+    minDailyDegeneration: z.number(),
+    maxDailyDegeneration: z.number(),
+    minDailyRecovery: z.number(),
+    maxDailyRecovery: z.number(),
+  })
+  .catchall(z.number());
+
+const DiseaseIntegrationHintsSchema = z
+  .object({
+    applyOrder: z.array(z.string()).optional(),
+    mapToDiseaseModel: z.record(z.string()).optional(),
+  })
+  .passthrough();
+
+export const DiseaseBalancingConfigSchema: z.ZodType<DiseaseBalancingConfig> = z
+  .object({
+    kind: z.string(),
+    version: z.string(),
+    notes: z.string().optional(),
+    global: DiseaseBalancingGlobalConfigSchema,
+    phaseMultipliers: z.record(DiseasePhaseMultipliersSchema),
+    environmentModifiers: z.record(DiseaseEnvironmentModifierSchema),
+    strainResistanceWeights: DiseaseStrainResistanceWeightsSchema,
+    treatmentEfficacy: z.record(DiseaseTreatmentEfficacySchema),
+    caps: DiseaseCapsSchema,
+    integrationHints: DiseaseIntegrationHintsSchema.optional(),
+  })
+  .passthrough();
+
+const PestBalancingGlobalConfigSchema = z
+  .object({
+    baseDailyReproductionMultiplier: z.number(),
+    baseDailyMortalityMultiplier: z.number(),
+    baseDamageMultiplier: z.number(),
+    maxConcurrentPests: z.number(),
+    economicThresholds: z.record(z.number()),
+    eventWeights: z.record(z.number()),
+  })
+  .passthrough();
+
+const PestPhaseMultipliersSchema = z
+  .object({
+    reproduction: z.number().optional(),
+    damage: z.number().optional(),
+    mortality: z.number().optional(),
+  })
+  .passthrough();
+
+const PestEnvironmentModifierSchema = z.record(
+  z.union([NumericTupleSchema, z.number(), z.boolean(), z.string()]),
+);
+
+const PestNaturalEnemiesConfigSchema = z
+  .object({
+    backgroundPredationPerDay: z.number(),
+    enhancedPredationWithBiocontrol: z.number(),
+  })
+  .catchall(z.number());
+
+const PestCapsSchema = z
+  .object({
+    minDailyReproduction: z.number(),
+    maxDailyReproduction: z.number(),
+    minDailyMortality: z.number(),
+    maxDailyMortality: z.number(),
+    minDailyDamage: z.number(),
+    maxDailyDamage: z.number(),
+  })
+  .catchall(z.number());
+
+const PestIntegrationHintsSchema = z
+  .object({
+    applyOrder: z.array(z.string()).optional(),
+    mapToPestModel: z.record(z.string()).optional(),
+  })
+  .passthrough();
+
+export const PestBalancingConfigSchema: z.ZodType<PestBalancingConfig> = z
+  .object({
+    kind: z.string(),
+    version: z.string(),
+    notes: z.string().optional(),
+    global: PestBalancingGlobalConfigSchema,
+    phaseMultipliers: z.record(PestPhaseMultipliersSchema),
+    environmentModifiers: z.record(PestEnvironmentModifierSchema),
+    naturalEnemies: PestNaturalEnemiesConfigSchema,
+    controlEfficacy: z.record(PestTreatmentEfficacySchema),
+    diseaseInteraction: z.record(z.number()),
+    caps: PestCapsSchema,
+    integrationHints: PestIntegrationHintsSchema.optional(),
+  })
+  .passthrough();
+
+const DiseaseModelSchema = z
+  .object({
+    dailyInfectionIncrement: z.number(),
+    infectionThreshold: z.number(),
+    degenerationRate: z.number(),
+    recoveryRate: z.number(),
+    regenerationRate: z.number().optional(),
+    fatalityThreshold: z.number(),
+  })
+  .catchall(z.number());
+
+const DiseaseDetectionSchema = z
+  .object({
+    symptoms: z.array(z.string()).optional(),
+    scoutingHints: z.array(z.string()).optional(),
+  })
+  .catchall(z.array(z.string()).optional());
+
+export const DiseaseDefinitionSchema: z.ZodType<DiseaseDefinition> = z
+  .object({
+    id: z.string(),
+    kind: z.string(),
+    name: z.string(),
+    pathogenType: z.string(),
+    targets: z.array(z.string()),
+    environmentalRisk: z.record(z.union([NumericTupleSchema, z.number(), z.boolean(), z.string()])),
+    transmission: z.array(z.string()),
+    contagious: z.boolean(),
+    model: DiseaseModelSchema,
+    detection: DiseaseDetectionSchema,
+    treatments: z.record(z.array(z.string())).optional(),
+  })
+  .passthrough();
+
+const PestDamageModelSchema = z.record(z.union([z.number(), z.boolean()]));
+
+const PestDetectionSchema = z
+  .object({
+    symptoms: z.array(z.string()).optional(),
+    monitoring: z.array(z.string()).optional(),
+  })
+  .catchall(z.array(z.string()).optional());
+
+export const PestDefinitionSchema: z.ZodType<PestDefinition> = z
+  .object({
+    id: z.string(),
+    kind: z.string(),
+    name: z.string(),
+    category: z.string(),
+    targets: z.array(z.string()),
+    environmentalRisk: z.record(z.union([NumericTupleSchema, z.number(), z.boolean(), z.string()])),
+    populationDynamics: z.record(z.number()),
+    damageModel: PestDamageModelSchema,
+    detection: PestDetectionSchema,
+    controlOptions: z.record(z.array(z.string())).optional(),
+  })
+  .passthrough();

--- a/src/game/health/types.ts
+++ b/src/game/health/types.ts
@@ -107,6 +107,43 @@ export interface RangeDescriptor {
 
 export type NumericTuple = [number, number];
 
+export interface DiseaseDefinition {
+  id: string;
+  kind: string;
+  name: string;
+  pathogenType: string;
+  targets: string[];
+  environmentalRisk: Record<string, number | NumericTuple | boolean | string | undefined>;
+  transmission: string[];
+  contagious: boolean;
+  model: Record<string, number>;
+  detection: {
+    symptoms?: string[];
+    scoutingHints?: string[];
+    [key: string]: unknown;
+  };
+  treatments?: Record<string, string[]>;
+  [key: string]: unknown;
+}
+
+export interface PestDefinition {
+  id: string;
+  kind: string;
+  name: string;
+  category: string;
+  targets: string[];
+  environmentalRisk: Record<string, number | NumericTuple | boolean | string | undefined>;
+  populationDynamics: Record<string, number>;
+  damageModel: Record<string, number | boolean>;
+  detection: {
+    symptoms?: string[];
+    monitoring?: string[];
+    [key: string]: unknown;
+  };
+  controlOptions?: Record<string, string[]>;
+  [key: string]: unknown;
+}
+
 export interface DiseaseBalancingGlobalConfig {
   baseDailyInfectionMultiplier: number;
   baseRecoveryMultiplier: number;
@@ -245,4 +282,6 @@ export interface HealthDefinitionData {
   diseaseBalancing: DiseaseBalancingConfig;
   pestBalancing: PestBalancingConfig;
   treatmentCatalog: TreatmentCatalog;
+  diseases: DiseaseDefinition[];
+  pests: PestDefinition[];
 }

--- a/src/lib/staticJson.ts
+++ b/src/lib/staticJson.ts
@@ -1,0 +1,150 @@
+import { z, ZodError, ZodIssue } from 'zod';
+
+const RAW_JSON_FILES = import.meta.glob('../data/**/*.json', {
+  eager: true,
+  as: 'raw',
+}) as Record<string, string>;
+
+const JSON_FILES: Record<string, string> = {};
+
+for (const [key, value] of Object.entries(RAW_JSON_FILES)) {
+  JSON_FILES[normalizeGlobKey(key)] = value;
+}
+
+function normalizeGlobKey(key: string): string {
+  if (key.startsWith('../')) {
+    return `/${key.slice(3)}`;
+  }
+  if (key.startsWith('./')) {
+    return key.slice(1);
+  }
+  if (!key.startsWith('/')) {
+    return `/${key}`;
+  }
+  return key;
+}
+
+function normalizeRequestedPath(path: string): string {
+  let normalized = path.trim();
+  if (normalized.startsWith('./')) {
+    normalized = normalized.slice(2);
+  }
+  if (normalized.startsWith('../')) {
+    normalized = normalized.replace(/^\.\.\//, '/');
+  }
+  if (normalized.startsWith('data/')) {
+    normalized = `/${normalized}`;
+  }
+  if (!normalized.startsWith('/')) {
+    throw new Error(`Unsupported data path '${path}'. Only files within /data can be loaded.`);
+  }
+  if (!normalized.startsWith('/data/')) {
+    throw new Error(`Unsupported data path '${path}'. Only files within /data can be loaded.`);
+  }
+  return normalized;
+}
+
+function normalizeDirectoryPath(path: string): string {
+  let normalized = normalizeRequestedPath(path);
+  if (!normalized.endsWith('/')) {
+    normalized = `${normalized}/`;
+  }
+  return normalized;
+}
+
+function formatIssuePath(path: (string | number)[]): string {
+  if (path.length === 0) {
+    return '<root>';
+  }
+  return path
+    .reduce<string>((acc, segment) => {
+      if (typeof segment === 'number') {
+        return `${acc}[${segment}]`;
+      }
+      return acc ? `${acc}.${segment}` : segment;
+    }, '');
+}
+
+function formatIssueExpectation(issue: ZodIssue): string {
+  switch (issue.code) {
+    case z.ZodIssueCode.invalid_type:
+      return `expected ${issue.expected}, received ${issue.received}`;
+    case z.ZodIssueCode.invalid_literal:
+      return `expected literal ${JSON.stringify(issue.expected)}`;
+    case z.ZodIssueCode.unrecognized_keys:
+      return `unrecognized keys: ${issue.keys.join(', ')}`;
+    case z.ZodIssueCode.invalid_union:
+      return `expected one of the union options`;
+    case z.ZodIssueCode.invalid_enum_value:
+      return `expected one of ${issue.options.join(', ')}, received ${issue.received}`;
+    case z.ZodIssueCode.too_small:
+      return `expected ${issue.type} with ${issue.inclusive ? '≥' : '>'} ${issue.minimum}`;
+    case z.ZodIssueCode.too_big:
+      return `expected ${issue.type} with ${issue.inclusive ? '≤' : '<'} ${issue.maximum}`;
+    default:
+      return issue.message;
+  }
+}
+
+export function formatZodError(filePath: string, error: ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = formatIssuePath(issue.path);
+    const expectation = formatIssueExpectation(issue);
+    return `${filePath} → ${path} → ${expectation}`;
+  });
+}
+
+export class DataValidationError extends Error {
+  readonly messages: string[];
+
+  constructor(messages: string[]) {
+    super(messages.join('\n'));
+    this.name = 'DataValidationError';
+    this.messages = messages;
+  }
+}
+
+export function parseJsonFile<T>(filePath: string, schema: z.ZodSchema<T>): T {
+  const normalizedPath = normalizeRequestedPath(filePath);
+  const raw = JSON_FILES[normalizedPath];
+
+  if (raw === undefined) {
+    throw new Error(`Could not locate static JSON file at ${normalizedPath}. Ensure it is included in the build.`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new DataValidationError([`${normalizedPath} → <root> → JSON parse error: ${message}`]);
+  }
+
+  try {
+    return schema.parse(parsed);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      throw new DataValidationError(formatZodError(normalizedPath, error));
+    }
+    throw error;
+  }
+}
+
+export function tryParseJsonFile<T>(filePath: string, schema: z.ZodSchema<T>, errors: string[]): T | undefined {
+  try {
+    return parseJsonFile(filePath, schema);
+  } catch (error) {
+    if (error instanceof DataValidationError) {
+      errors.push(...error.messages);
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+export function listJsonFiles(prefix: string): string[] {
+  const normalizedPrefix = normalizeDirectoryPath(prefix);
+  return Object.keys(JSON_FILES)
+    .filter((path) => path.startsWith(normalizedPrefix))
+    .sort();
+}


### PR DESCRIPTION
## Summary
- replace the fetch-based blueprint loader with a static JSON importer that surfaces aggregated zod validation errors
- add reusable static JSON utilities and comprehensive zod schemas for blueprint, pricing, personnel, and health data assets
- validate disease and pest definitions alongside balancing configs via a new loadAllHealthData helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccc39cab3c83259427e75e0cd0580d