### PR TITLE
Refactor RNG handling and add determinism tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-test
 dist-ssr
 *.local
 

--- a/game/engine.ts
+++ b/game/engine.ts
@@ -1,5 +1,5 @@
 import { GameState, Company } from './types';
-import { mulberry32 } from './utils';
+import { createSeededRandomAdapter } from './utils';
 
 export function initialGameState(companyName: string = 'Weedbreed', seed?: number): GameState {
   const gameSeed = seed ?? Date.now();
@@ -36,7 +36,7 @@ export function initialGameState(companyName: string = 'Weedbreed', seed?: numbe
 
 export async function gameTick(currentState: GameState): Promise<GameState> {
   // Create a new deterministic RNG for this specific tick
-  const rng = mulberry32(currentState.seed + currentState.ticks);
+  const rng = createSeededRandomAdapter(currentState.seed + currentState.ticks);
 
   // The company object will be mutated, but we create a new top-level object
   // to ensure React detects the state change.

--- a/game/models/Company.ts
+++ b/game/models/Company.ts
@@ -2,7 +2,8 @@
 
 import { Structure, StructureBlueprint, StrainBlueprint, Zone, Company as ICompany, FinancialLedger, ExpenseCategory, Plant, Planting, RevenueCategory, Alert, AlertType, Employee, SkillName, Skill, Trait, JobRole, Task, TaskType, TaskLocation, PlantingPlan, OvertimePolicy } from '../types';
 import { getAvailableStrains, getBlueprints } from '../blueprints';
-import { yieldToMainThread, RandomAdapter } from '../utils';
+import { yieldToMainThread } from '../utils';
+import type { RandomAdapter } from '../utils';
 import * as finance from '../services/finance';
 import * as hr from '../services/hr';
 import * as market from '../services/market';
@@ -91,7 +92,7 @@ export class Company {
     return finance.spendCapital(this, amount);
   }
 
-  purchaseDevicesForZone(blueprintId: string, zone: Zone, quantity: number, rng: () => number): boolean {
+  purchaseDevicesForZone(blueprintId: string, zone: Zone, quantity: number, rng: RandomAdapter): boolean {
     const blueprints = getBlueprints();
     const priceInfo = blueprints.devicePrices[blueprintId];
 
@@ -171,20 +172,20 @@ export class Company {
     hr.declineRaise(this, employeeId);
   }
   
-  async updateJobMarket(rng: () => number, ticks: number, seed: number): Promise<void> {
+  async updateJobMarket(rng: RandomAdapter, ticks: number, seed: number): Promise<void> {
     await market.updateJobMarket(this, rng, ticks, seed);
   }
 
-  breedStrain(parentA: StrainBlueprint, parentB: StrainBlueprint, newName: string, rng: () => number): StrainBlueprint | null {
+  breedStrain(parentA: StrainBlueprint, parentB: StrainBlueprint, newName: string, rng: RandomAdapter): StrainBlueprint | null {
       if (!parentA || !parentB) {
         console.error("Parent strains not found for breeding.");
         return null;
       }
       
-      const random = new RandomAdapter(rng);
+      const random = rng;
       const newStrain: StrainBlueprint = JSON.parse(JSON.stringify(parentA));
 
-      newStrain.id = `custom-${Date.now()}-${rng()}`;
+      newStrain.id = `custom-${Date.now()}-${random.float()}`;
       newStrain.name = newName;
       newStrain.slug = newName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
       newStrain.lineage.parents = [parentA.name, parentB.name];
@@ -355,7 +356,7 @@ export class Company {
         }
     }
 
-    async update(rng: () => number, ticks: number, seed: number) {
+    async update(rng: RandomAdapter, ticks: number, seed: number) {
         this.checkForAlerts(ticks);
 
         if (ticks > 0 && ticks % (24 * 7) === 0) {

--- a/game/models/Planting.ts
+++ b/game/models/Planting.ts
@@ -1,5 +1,7 @@
 import { Plant, GrowthStage } from './Plant';
 import { StrainBlueprint } from '../types';
+import type { RandomAdapter } from '../utils';
+import { createRandomAdapter } from '../utils';
 
 interface Environment {
     temperature_C: number;
@@ -21,11 +23,11 @@ export class Planting {
         // accepts a pre-populated array of Plant instances. This responsibility
         // correctly lies with the calling code (e.g., Zone.ts), which already
         // uses the deterministic RNG. This removes the problematic branch that
-        // could have used Math.random.
+        // previously relied on non-deterministic randomness.
         if (data.plants && data.plants.length > 0 && !(data.plants[0] instanceof Plant)) {
             // Loading from save: data.plants is an array of plain objects. Rehydrate them.
             this.plants = data.plants.map((plantData: any) => {
-                const plant = new Plant(plantData.strainId, () => 0); // Dummy RNG for rehydration
+                const plant = new Plant(plantData.strainId, createRandomAdapter(() => 0)); // Dummy RNG for rehydration
                 Object.assign(plant, plantData); // Re-hydrate instance
                 return plant;
             });
@@ -40,7 +42,7 @@ export class Planting {
         this.quantity = this.plants.length;
     }
 
-    update(strain: StrainBlueprint, environment: Environment, rng: () => number, isLightOn: boolean, hasWater: boolean, hasNutrients: boolean, lightOnHours: number, diseaseChance: number) {
+    update(strain: StrainBlueprint, environment: Environment, rng: RandomAdapter, isLightOn: boolean, hasWater: boolean, hasNutrients: boolean, lightOnHours: number, diseaseChance: number) {
         this.plants.forEach(plant => {
             if (plant.growthStage !== GrowthStage.Dead) {
                 plant.update(strain, environment, rng, isLightOn, hasWater, hasNutrients, lightOnHours, diseaseChance);

--- a/game/models/Room.ts
+++ b/game/models/Room.ts
@@ -2,6 +2,7 @@ import { Zone } from './Zone';
 import { RoomPurpose } from '../roomPurposes';
 import { Company, StrainBlueprint, Structure, Device } from '../types';
 import { GrowthStage } from './Plant';
+import type { RandomAdapter } from '../utils';
 
 export class Room {
   id: string;
@@ -59,7 +60,7 @@ export class Room {
     delete this.zones[zoneId];
   }
 
-  duplicateZone(zoneId: string, company: Company, rng: () => number): Zone | null {
+  duplicateZone(zoneId: string, company: Company, rng: RandomAdapter): Zone | null {
     const originalZone = this.zones[zoneId];
     if (!originalZone) {
       console.error(`Zone with id ${zoneId} not found in room ${this.id}`);
@@ -84,7 +85,7 @@ export class Room {
 
     // Create the copy
     const newZoneData = originalZone.toJSON(); // Get a clean data object
-    newZoneData.id = `zone-${Date.now()}-${rng()}`;
+    newZoneData.id = `zone-${Date.now()}-${rng.float()}`;
     newZoneData.name = `${originalZone.name} (Copy)`;
     newZoneData.plantings = {}; // CRITICAL: Do not copy plants
     newZoneData.waterLevel_L = 0;
@@ -94,7 +95,7 @@ export class Room {
     const newDevices: Record<string, Device> = {};
     for (const deviceId in newZoneData.devices) {
       const oldDevice = newZoneData.devices[deviceId];
-      const newDeviceId = `device-${Date.now()}-${rng()}`;
+      const newDeviceId = `device-${Date.now()}-${rng.float()}`;
       newDevices[newDeviceId] = {
         ...oldDevice,
         id: newDeviceId,
@@ -172,7 +173,7 @@ export class Room {
     }, 0);
   }
 
-  async update(company: Company, structure: Structure, rng: () => number, ticks: number) {
+  async update(company: Company, structure: Structure, rng: RandomAdapter, ticks: number) {
     for (const zoneId in this.zones) {
       this.zones[zoneId].update(company, structure, rng, ticks);
     }

--- a/game/models/Structure.ts
+++ b/game/models/Structure.ts
@@ -5,6 +5,7 @@ import { StructureBlueprint, Company, StrainBlueprint, Device, Employee, SkillNa
 import { GrowthStage } from './Plant';
 import { getAvailableStrains, getBlueprints } from '../blueprints';
 import { TICKS_PER_MONTH } from '../constants/balance';
+import type { RandomAdapter } from '../utils';
 
 export class Structure {
   id: string;
@@ -67,7 +68,7 @@ export class Structure {
     delete this.rooms[roomId];
   }
   
-  duplicateRoom(roomId: string, company: Company, rng: () => number): Room | null {
+  duplicateRoom(roomId: string, company: Company, rng: RandomAdapter): Room | null {
     const originalRoom = this.rooms[roomId];
     if (!originalRoom) {
       console.error(`Room with id ${roomId} not found in structure ${this.id}`);
@@ -106,7 +107,7 @@ export class Structure {
     for (const zoneId in originalRoom.zones) {
       const originalZone = originalRoom.zones[zoneId];
       const newZoneData = originalZone.toJSON();
-      newZoneData.id = `zone-${Date.now()}-${rng()}`;
+      newZoneData.id = `zone-${Date.now()}-${rng.float()}`;
       newZoneData.plantings = {};
       newZoneData.waterLevel_L = 0;
       newZoneData.nutrientLevel_g = 0;
@@ -114,7 +115,7 @@ export class Structure {
       const newDevices: Record<string, any> = {};
       for (const deviceId in newZoneData.devices) {
         const oldDevice = newZoneData.devices[deviceId];
-        const newDeviceId = `device-${Date.now()}-${rng()}`;
+        const newDeviceId = `device-${Date.now()}-${rng.float()}`;
         newDevices[newDeviceId] = {
           ...oldDevice,
           id: newDeviceId,
@@ -239,7 +240,7 @@ export class Structure {
       return this.getEmployees(company).filter(emp => emp.status === 'Resting').length;
   }
 
-  async update(company: Company, rng: () => number, ticks: number) {
+  async update(company: Company, rng: RandomAdapter, ticks: number) {
     for (const roomId in this.rooms) {
       await this.rooms[roomId].update(company, this, rng, ticks);
     }

--- a/game/models/Zone.ts
+++ b/game/models/Zone.ts
@@ -3,6 +3,7 @@ import { getBlueprints, getAvailableStrains } from '../blueprints';
 import { Planting } from './Planting';
 import { Plant, GrowthStage } from './Plant';
 import * as ENV from '../constants/environment';
+import type { RandomAdapter } from '../utils';
 
 export class Zone {
   id: string;
@@ -151,7 +152,7 @@ export class Zone {
     });
   }
 
-  addDevice(blueprintId: string, rng: () => number): void {
+  addDevice(blueprintId: string, rng: RandomAdapter): void {
     const blueprints = getBlueprints();
     const blueprint = blueprints.devices[blueprintId];
     if (!blueprint) {
@@ -161,7 +162,7 @@ export class Zone {
     
     const priceInfo = blueprints.devicePrices[blueprintId];
 
-    const newDeviceId = `device-${Date.now()}-${rng()}`;
+    const newDeviceId = `device-${Date.now()}-${rng.float()}`;
     const newDevice: Device = {
       id: newDeviceId,
       blueprintId: blueprintId,
@@ -302,7 +303,7 @@ export class Zone {
     };
   }
 
-  plantStrain(strainId: string, quantity: number, company: Company, rng: () => number): { germinatedCount: number } {
+  plantStrain(strainId: string, quantity: number, company: Company, rng: RandomAdapter): { germinatedCount: number } {
     const capacity = this.getPlantCapacity();
     const currentCount = this.getTotalPlantedCount();
 
@@ -322,7 +323,7 @@ export class Zone {
     const germinationRate = strainBlueprint.germinationRate ?? 1.0;
     const germinatedPlants: Plant[] = [];
     for (let i = 0; i < quantity; i++) {
-        if (rng() <= germinationRate) {
+        if (rng.float() <= germinationRate) {
             germinatedPlants.push(new Plant(strainId, rng));
         }
     }
@@ -544,7 +545,7 @@ export class Zone {
     this.currentEnvironment.co2_ppm = Math.max(0, this.currentEnvironment.co2_ppm);
   }
 
-  update(company: Company, structure: Structure, rng: () => number, ticks: number) {
+  update(company: Company, structure: Structure, rng: RandomAdapter, ticks: number) {
       if (this.status !== 'Growing') {
         return;
       }

--- a/game/services/hr.ts
+++ b/game/services/hr.ts
@@ -1,6 +1,7 @@
 import { Company, Employee, JobRole, Skill, SkillName, Task, Trait, OvertimePolicy } from '../types';
 import { resolveTask } from './taskEngine';
 import * as BALANCE from '../constants/balance';
+import type { RandomAdapter } from '../utils';
 
 export function hireEmployee(company: Company, employee: Employee, structureId: string, ticks: number): boolean {
     if (company.employees[employee.id]) {
@@ -96,7 +97,7 @@ export function assignEmployeeRole(company: Company, employeeId: string, role: J
     }
 }
 
-export function updateEmployeesAI(company: Company, ticks: number, rng: () => number) {
+export function updateEmployeesAI(company: Company, ticks: number, rng: RandomAdapter) {
       const tasksInProgress = new Set<string>();
       Object.values(company.employees).forEach(emp => {
           if (emp.status === 'Working' && emp.currentTask) {
@@ -197,14 +198,14 @@ export function updateEmployeesAI(company: Company, ticks: number, rng: () => nu
       }
 }
 
-export function processDailyUpdates(company: Company, ticks: number, rng: () => number) {
+export function processDailyUpdates(company: Company, ticks: number, rng: RandomAdapter) {
     let totalSalaries = 0;
     const employeesToQuit: string[] = [];
 
     Object.values(company.employees).forEach(emp => {
         totalSalaries += emp.salaryPerDay;
         
-        if (emp.morale < 20 && rng() < BALANCE.LOW_MORALE_QUIT_CHANCE_PER_DAY) {
+        if (emp.morale < 20 && rng.chance(BALANCE.LOW_MORALE_QUIT_CHANCE_PER_DAY)) {
             employeesToQuit.push(emp.id);
         }
 
@@ -216,7 +217,7 @@ export function processDailyUpdates(company: Company, ticks: number, rng: () => 
             const baseSalary = 50 + (totalSkillPoints * 8);
             
             if (baseSalary > emp.salaryPerDay * 1.05) {
-                const newSalary = baseSalary * (1 + (rng() - 0.5) * 0.1);
+                const newSalary = baseSalary * (1 + (rng.float() - 0.5) * 0.1);
                 const alertKey = `${emp.id}-raise_request`;
                 const existingAlert = company.alerts.find(a => a.id.startsWith(`alert-${alertKey}`));
                 if (!existingAlert) {

--- a/game/services/taskEngine.ts
+++ b/game/services/taskEngine.ts
@@ -2,6 +2,7 @@ import { Company, Employee, Task, TaskType } from '../types';
 import { getAvailableStrains, getBlueprints } from '../blueprints';
 import { GrowthStage } from '../models/Plant';
 import { TASK_XP_REWARD, XP_PER_LEVEL } from '../constants/balance';
+import type { RandomAdapter } from '../utils';
 
 export function generateTasks(company: Company) {
     const definitions = getBlueprints().taskDefinitions;
@@ -122,7 +123,7 @@ export function generateTasks(company: Company) {
 }
 
 
-export function resolveTask(company: Company, employee: Employee, task: Task, ticks: number, rng: () => number) {
+export function resolveTask(company: Company, employee: Employee, task: Task, ticks: number, rng: RandomAdapter) {
     const structure = company.structures[task.location.structureId];
     if (!structure) return;
     const room = structure.rooms[task.location.roomId];

--- a/game/types.ts
+++ b/game/types.ts
@@ -1,14 +1,14 @@
 
 
-import { RoomPurpose } from './roomPurposes';
-import { Company } from './models/Company';
-import { Structure } from './models/Structure';
-import { Room } from './models/Room';
-import { Zone } from './models/Zone';
-import { Planting } from './models/Planting';
-import { Plant } from './models/Plant';
+import type { Company } from './models/Company';
 
-export { Company, Structure, Room, Zone, Planting, Plant, RoomPurpose };
+export { Company } from './models/Company';
+export { Structure } from './models/Structure';
+export { Room } from './models/Room';
+export { Zone } from './models/Zone';
+export { Planting } from './models/Planting';
+export { Plant } from './models/Plant';
+export type { RoomPurpose } from './roomPurposes';
 
 export interface StructureBlueprint {
   id: string;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "npm run test:build && node -e \"const fs=require('fs');fs.mkdirSync('dist-test',{recursive:true});fs.writeFileSync('dist-test/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\" && node --test dist-test/tests",
+    "test:build": "tsc --project tsconfig.test.json"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/tests/determinism.test.ts
+++ b/tests/determinism.test.ts
@@ -1,0 +1,223 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+import { createSeededRandomAdapter } from '../game/utils';
+import { Company } from '../game/models/Company';
+import { processDailyUpdates } from '../game/services/hr';
+import { Zone } from '../game/models/Zone';
+import { loadAllBlueprints, getBlueprints } from '../game/blueprints';
+
+// Provide a deterministic no-op alert implementation for Node-based tests.
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+(globalThis as any).alert = () => {};
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+let blueprintsLoaded = false;
+const originalFetch = globalThis.fetch;
+
+async function ensureBlueprintsLoaded() {
+  if (blueprintsLoaded) {
+    return;
+  }
+
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (!url.startsWith('/data/')) {
+      throw new Error(`Unsupported fetch request during tests: ${url}`);
+    }
+
+    const filePath = path.resolve(projectRoot, `.${url}`);
+    const data = await fs.readFile(filePath, 'utf8');
+    return {
+      ok: true,
+      json: async () => JSON.parse(data),
+    } as Response;
+  };
+
+  await loadAllBlueprints();
+  blueprintsLoaded = true;
+}
+
+function createBaseCompanyData() {
+  return {
+    id: 'company-test',
+    name: 'Determinism Labs',
+    capital: 100000,
+    structures: {
+      'structure-1': {
+        id: 'structure-1',
+        blueprintId: 'small_warehouse',
+        name: 'Main Facility',
+        area_m2: 100,
+        height_m: 5,
+        rooms: {
+          'room-1': {
+            id: 'room-1',
+            name: 'Break Area',
+            area_m2: 20,
+            purpose: 'breakroom',
+            zones: {},
+          },
+        },
+        employeeIds: ['emp-1'],
+        tasks: [],
+      },
+    },
+    customStrains: {},
+    employees: {
+      'emp-1': {
+        id: 'emp-1',
+        firstName: 'Alex',
+        lastName: 'Taylor',
+        salaryPerDay: 120,
+        role: 'Gardener',
+        skills: {
+          Gardening: { name: 'Gardening', level: 5, xp: 0 },
+          Maintenance: { name: 'Maintenance', level: 3, xp: 0 },
+          Technical: { name: 'Technical', level: 2, xp: 0 },
+          Cleanliness: { name: 'Cleanliness', level: 4, xp: 0 },
+          Botanical: { name: 'Botanical', level: 3, xp: 0 },
+          Negotiation: { name: 'Negotiation', level: 1, xp: 0 },
+        },
+        traits: [],
+        energy: 80,
+        morale: 18,
+        structureId: 'structure-1',
+        status: 'Idle',
+        currentTask: null,
+        leaveHours: 0,
+        lastRaiseTick: 0,
+      },
+    },
+    jobMarketCandidates: [],
+    ledger: {
+      revenue: { harvests: 0, other: 0 },
+      expenses: { rent: 0, maintenance: 0, power: 0, structures: 0, devices: 0, supplies: 0, seeds: 0, salaries: 0 },
+    },
+    cumulativeYield_g: 0,
+    alerts: [],
+    alertCooldowns: {},
+    overtimePolicy: 'payout',
+  };
+}
+
+function createTestCompany() {
+  return new Company(createBaseCompanyData());
+}
+
+function withFixedNow<T>(value: number, fn: () => T): T {
+  const original = Date.now;
+  Date.now = () => value;
+  try {
+    return fn();
+  } finally {
+    Date.now = original;
+  }
+}
+
+function sanitizeCompany(company: Company) {
+  return {
+    snapshot: company.toJSON(),
+    capital: company.capital,
+    jobMarketCandidates: company.jobMarketCandidates,
+  };
+}
+
+test('seeded random adapters produce deterministic sequences', () => {
+  const rngA = createSeededRandomAdapter(42);
+  const rngB = createSeededRandomAdapter(42);
+  const sequenceA = Array.from({ length: 5 }, () => rngA.float());
+  const sequenceB = Array.from({ length: 5 }, () => rngB.float());
+  assert.deepStrictEqual(sequenceA, sequenceB);
+
+  const rngC = createSeededRandomAdapter(7);
+  const sequenceC = Array.from({ length: 5 }, () => rngC.float());
+  assert.notDeepStrictEqual(sequenceA, sequenceC);
+});
+
+test('processDailyUpdates is deterministic with a fixed seed', () => {
+  const companyA = createTestCompany();
+  const companyB = createTestCompany();
+  const seed = 2025;
+  const rngA = createSeededRandomAdapter(seed);
+  const rngB = createSeededRandomAdapter(seed);
+
+  processDailyUpdates(companyA, 48, rngA);
+  processDailyUpdates(companyB, 48, rngB);
+
+  assert.deepStrictEqual(sanitizeCompany(companyA), sanitizeCompany(companyB));
+});
+
+test('zone planting yields deterministic germination results', async () => {
+  await ensureBlueprintsLoaded();
+  const companyA = createTestCompany();
+  const companyB = createTestCompany();
+
+  const baseZoneData = {
+    id: 'zone-1',
+    name: 'Test Zone',
+    area_m2: 20,
+    cultivationMethodId: 'basic_soil_pot',
+    devices: {},
+    plantings: {},
+    lightCycle: { on: 18, off: 6 },
+    status: 'Ready' as const,
+    waterLevel_L: 0,
+    nutrientLevel_g: 0,
+    deviceGroupSettings: {},
+    cyclesUsed: 0,
+  };
+
+  const zoneA = new Zone(baseZoneData);
+  const zoneB = new Zone({ ...baseZoneData, id: 'zone-2' });
+
+  const seed = 1337;
+  const rngA = createSeededRandomAdapter(seed);
+  const rngB = createSeededRandomAdapter(seed);
+
+  const strainId = Object.keys(getBlueprints().strains)[0];
+  assert.ok(strainId, 'Expected at least one strain blueprint');
+
+  const fixedTimestamp = 1_700_000_000_000;
+  const resultA = withFixedNow(fixedTimestamp, () => zoneA.plantStrain(strainId, 5, companyA, rngA));
+  const resultB = withFixedNow(fixedTimestamp, () => zoneB.plantStrain(strainId, 5, companyB, rngB));
+
+  assert.deepStrictEqual(resultA, resultB);
+  assert.strictEqual(zoneA.getTotalPlantedCount(), zoneB.getTotalPlantedCount());
+});
+
+test('codebase avoids Math RNG usage', async () => {
+  async function* walk(dir: string): AsyncGenerator<string> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'dist-test' || entry.name.startsWith('.')) {
+        continue;
+      }
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        yield* walk(fullPath);
+      } else if (entry.isFile()) {
+        yield fullPath;
+      }
+    }
+  }
+
+  for await (const filePath of walk(projectRoot)) {
+    const relativePath = path.relative(projectRoot, filePath);
+    if (!/\.(ts|tsx|js|jsx)$/.test(filePath)) {
+      continue;
+    }
+    const content = await fs.readFile(filePath, 'utf8');
+    const forbidden = `Math.${'random'}`;
+    assert.ok(!content.includes(forbidden), `Found forbidden ${forbidden} usage in ${relativePath}`);
+  }
+});
+
+process.on('exit', () => {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist-test",
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "allowImportingTsExtensions": false,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "esModuleInterop": true
+  },
+  "include": [
+    "game/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "dist-test",
+    "game/api.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- replace raw RNG usage with a shared random adapter helper and seed-aware factories
- update company, zone, HR, and market flows to consume the adapter instead of raw closures for consistent IDs and events
- add deterministic integration tests plus a node-based harness enforcing the Math.random ban

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cccdd3eb448325ac3dc744033284bb