### PR TITLE
Refactor type exports to avoid model re-exports

### DIFF
--- a/game/blueprints.ts
+++ b/game/blueprints.ts
@@ -1,6 +1,5 @@
 import type {
   BlueprintDB,
-  Company,
   CultivationMethodBlueprint,
   DeviceBlueprint,
   PersonnelData,
@@ -9,6 +8,7 @@ import type {
   TaskDefinition,
   TaskType,
 } from './types';
+import type { Company } from './models/Company';
 import {
   BlueprintManifestSchema,
   CultivationMethodBlueprintSchema,

--- a/game/engine.ts
+++ b/game/engine.ts
@@ -1,4 +1,5 @@
-import { GameState, Company } from './types';
+import type { GameState } from './types';
+import { Company } from './models/Company';
 import { createSeededRandom } from './utils';
 
 export function initialGameState(companyName: string = 'Weedbreed', seed?: number): GameState {

--- a/game/models/Company.ts
+++ b/game/models/Company.ts
@@ -1,5 +1,17 @@
 
-import { Structure, StructureBlueprint, StrainBlueprint, Zone, FinancialLedger, ExpenseCategory, Plant, Planting, RevenueCategory, Alert, AlertType, Employee, Task, PlantingPlan, OvertimePolicy } from '../types';
+import type {
+  StructureBlueprint,
+  StrainBlueprint,
+  FinancialLedger,
+  ExpenseCategory,
+  RevenueCategory,
+  Alert,
+  AlertType,
+  Employee,
+  Task,
+  PlantingPlan,
+  OvertimePolicy,
+} from '../types';
 import { getBlueprints } from '../blueprints';
 import { createSeededRandom, RandomGenerator } from '../utils';
 import { FinanceService } from './company/FinanceService';
@@ -7,6 +19,10 @@ import { HRService } from './company/HRService';
 import { TaskEngine } from './company/TaskEngine';
 import { MarketService } from './company/MarketService';
 import { MUTATION_FACTOR, ALERT_COOLDOWN_TICKS } from '../constants/balance';
+import { Structure } from './Structure';
+import type { Zone } from './Zone';
+import type { Plant } from './Plant';
+import type { Planting } from './Planting';
 
 
 export class Company {

--- a/game/models/Plant.ts
+++ b/game/models/Plant.ts
@@ -1,4 +1,4 @@
-import { StrainBlueprint } from '../types';
+import type { StrainBlueprint } from '../types';
 import { RandomGenerator } from '../utils';
 
 export enum GrowthStage {

--- a/game/models/Planting.ts
+++ b/game/models/Planting.ts
@@ -1,5 +1,5 @@
 import { Plant, GrowthStage } from './Plant';
-import { StrainBlueprint } from '../types';
+import type { StrainBlueprint } from '../types';
 import { RandomGenerator } from '../utils';
 
 interface Environment {

--- a/game/models/Room.ts
+++ b/game/models/Room.ts
@@ -1,6 +1,8 @@
 import { Zone } from './Zone';
-import { RoomPurpose } from '../roomPurposes';
-import { Company, StrainBlueprint, Structure, Device } from '../types';
+import type { RoomPurpose } from '../roomPurposes';
+import type { StrainBlueprint, Device } from '../types';
+import type { Company } from './Company';
+import type { Structure } from './Structure';
 import { GrowthStage } from './Plant';
 import { RandomGenerator } from '../utils';
 

--- a/game/models/Structure.ts
+++ b/game/models/Structure.ts
@@ -3,11 +3,21 @@
 
 import { Room } from './Room';
 import { Zone } from './Zone';
-import { RoomPurpose } from '../roomPurposes';
-import { StructureBlueprint, Company, StrainBlueprint, Device, Employee, SkillName, JobRole, Task, TaskType } from '../types';
+import type { RoomPurpose } from '../roomPurposes';
+import type {
+  StructureBlueprint,
+  StrainBlueprint,
+  Device,
+  Employee,
+  SkillName,
+  JobRole,
+  Task,
+  TaskType,
+} from '../types';
 import { GrowthStage } from './Plant';
 import { getAvailableStrains, getBlueprints } from '../blueprints';
 import { RandomGenerator } from '../utils';
+import type { Company } from './Company';
 
 const TICKS_PER_MONTH = 30;
 

--- a/game/models/Zone.ts
+++ b/game/models/Zone.ts
@@ -1,8 +1,18 @@
-import { Device, Company, StrainBlueprint, CultivationMethodBlueprint, DeviceBlueprint, GroupedDeviceInfo, Structure, Planting as IPlanting, ZoneStatus, PlantingPlan as IPlantingPlan } from '../types';
+import type {
+  Device,
+  Company,
+  StrainBlueprint,
+  CultivationMethodBlueprint,
+  DeviceBlueprint,
+  GroupedDeviceInfo,
+  ZoneStatus,
+  PlantingPlan,
+} from '../types';
 import { getBlueprints, getAvailableStrains } from '../blueprints';
 import { Planting } from './Planting';
 import { Plant, GrowthStage } from './Plant';
 import { RandomGenerator } from '../utils';
+import type { Structure } from './Structure';
 import {
   RECOMMENDED_AIR_CHANGES_PER_HOUR,
   BASE_DEHUMIDIFICATION_LOAD_KG_PER_M2_HOUR,
@@ -35,7 +45,7 @@ export class Zone {
   nutrientLevel_g: number;
   cyclesUsed: number;
   status: ZoneStatus;
-  plantingPlan: IPlantingPlan | null;
+  plantingPlan: PlantingPlan | null;
   currentEnvironment: {
     temperature_C: number;
     humidity_rh: number; // 0-1
@@ -115,7 +125,7 @@ export class Zone {
     };
   }
   
-  setPlantingPlan(plan: IPlantingPlan | null) {
+  setPlantingPlan(plan: PlantingPlan | null) {
     this.plantingPlan = plan;
   }
   

--- a/game/types.ts
+++ b/game/types.ts
@@ -1,15 +1,6 @@
+import type { Company } from './models/Company';
 
-
-import type { RoomPurpose } from './roomPurposes';
-import { Company } from './models/Company';
-import { Structure } from './models/Structure';
-import { Room } from './models/Room';
-import { Zone } from './models/Zone';
-import { Planting } from './models/Planting';
-import { Plant } from './models/Plant';
-
-export { Company, Structure, Room, Zone, Planting, Plant };
-export type { RoomPurpose };
+export type { RoomPurpose } from './roomPurposes';
 
 export interface StructureBlueprint {
   id: string;

--- a/src/game/api/index.ts
+++ b/src/game/api/index.ts
@@ -87,15 +87,18 @@ export function applyTreatmentToPlant(
   return adapter.applyTreatmentToPlant(plantId, treatmentId);
 }
 
-export { Company, Structure, Room, Zone, Planting, Plant } from '@/game/types';
+export { Company } from '@/game/models/Company';
+export { Structure } from '@/game/models/Structure';
+export { Room } from '@/game/models/Room';
+export { Zone } from '@/game/models/Zone';
+export { Planting } from '@/game/models/Planting';
+export { Plant } from '@/game/models/Plant';
 
 export type {
   GameState,
   StructureBlueprint,
   RoomPurpose,
   JobRole,
-  Planting,
-  Plant,
   PlantingPlan,
   Alert,
   Employee,
@@ -108,6 +111,8 @@ export type {
   Trait,
   OvertimePolicy,
 } from '@/game/types';
+export type { Planting } from '@/game/models/Planting';
+export type { Plant } from '@/game/models/Plant';
 
 export { roomPurposes } from '@/game/roomPurposes';
 export {


### PR DESCRIPTION
## Summary
- limit `game/types.ts` to pure interface and type aliases while keeping a type-only link to `Company`
- update model and engine modules to import class implementations directly and use `import type` for shared interfaces
- point the public API re-exports to the actual model modules instead of `game/types`

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccdeda1c408325835a47a5eb2d29ca